### PR TITLE
FIX: subtle bug when val size is 0

### DIFF
--- a/finetune/base.py
+++ b/finetune/base.py
@@ -368,7 +368,7 @@ class BaseModel(object, metaclass=ABCMeta):
         seq_lengths = [len(x) for x in encoded_output.token_ids]
         x = np.zeros((n, self.config.max_length, 2), dtype=np.int32)
         mask = np.zeros((n, self.config.max_length), dtype=np.float32)
-        labels_arr = np.full((n, self.config.max_length), PAD_TOKEN, dtype='object') if encoded_output.labels else None
+        labels_arr = np.full((n, self.config.max_length), PAD_TOKEN, dtype='object') if encoded_output.labels is not None else None
         for i, seq_length in enumerate(seq_lengths):
             # BPE embedding
             x[i, :seq_length, 0] = encoded_output.token_ids[i]


### PR DESCRIPTION
When val size is 0, it is required to pass a 0 len array around. Nones will break the label encoder. This bug was introduced when fixing the validation and batch size stuff as it requires two calls to the label encoder now.