### PR TITLE
Comment update

### DIFF
--- a/finetune/network_modules.py
+++ b/finetune/network_modules.py
@@ -115,8 +115,8 @@ def classifier(hidden, targets, n_classes, dropout_placeholder, config, train=Fa
     A simple linear classifier.
 
     :param hidden: The output of the featurizer. [batch_size, embed_dim]
-    :param targets: The placeholder representing the sparse target ids. [batch_size]
-    :param n_classes: A python int containing the number of classes that the model should be learning to predict over.
+    :param targets: The placeholder representing the sparse target ids. [batch_size, 2]
+    :param n_classes: the length of one-hot representation. 2
     :param dropout_placeholder:
     :param config: A config object, containing all parameters for the featurizer.
     :param train: If this flag is true, dropout and losses are added to the graph.

--- a/finetune/network_modules.py
+++ b/finetune/network_modules.py
@@ -116,7 +116,7 @@ def classifier(hidden, targets, n_classes, dropout_placeholder, config, train=Fa
 
     :param hidden: The output of the featurizer. [batch_size, embed_dim]
     :param targets: The placeholder representing the sparse target ids. [batch_size, 2]
-    :param n_classes: the length of one-hot representation. 2
+    :param n_classes: the length of transformed representation. 2
     :param dropout_placeholder:
     :param config: A config object, containing all parameters for the featurizer.
     :param train: If this flag is true, dropout and losses are added to the graph.


### PR DESCRIPTION
The `param targets` fed to classifier is the target label after being fit_transform(). The shape of `param targets` should be [batch size, 2]
For example, we have classification task with 3 categories: 0,1,2.  
The list of labels [0, 1, 2] will be transformed to [array([1, 0]), array([0.5, 0.5]), array([0, 1])]
I am not sure whether I misunderstand but `n_classes` here may not refer to number of classes?