### PR TITLE
FIX: tensorboard passthrough

### DIFF
--- a/docker/start_docker.sh
+++ b/docker/start_docker.sh
@@ -7,4 +7,4 @@ get_abs_filename() {
 DOCKER_DIR=`dirname $0`
 PROJECT_ROOT=$(get_abs_filename "$( dirname $DOCKER_DIR )")
 echo "Forwaring host folder $PROJECT_ROOT to container folder /Finetune"
-docker run --runtime=nvidia -d -v $PROJECT_ROOT:/Finetune -p 6006:6006 --name finetune finetune
+docker run --runtime=nvidia -d -v $PROJECT_ROOT:/Finetune $@ --name finetune finetune

--- a/docker/start_docker.sh
+++ b/docker/start_docker.sh
@@ -7,4 +7,4 @@ get_abs_filename() {
 DOCKER_DIR=`dirname $0`
 PROJECT_ROOT=$(get_abs_filename "$( dirname $DOCKER_DIR )")
 echo "Forwaring host folder $PROJECT_ROOT to container folder /Finetune"
-docker run --runtime=nvidia -d -v $PROJECT_ROOT:/Finetune --name finetune finetune 
+docker run --runtime=nvidia -d -v $PROJECT_ROOT:/Finetune -p 6006:6006 --name finetune finetune

--- a/finetune/base.py
+++ b/finetune/base.py
@@ -230,6 +230,7 @@ class BaseModel(object, metaclass=ABCMeta):
                 global_step += 1
                 if global_step % self.config.val_interval == 0:
                     feed_dict[self.do_dropout] = DROPOUT_OFF
+
                     outputs = self._eval(self.summaries, feed_dict=feed_dict)
                     if self.train_writer is not None:
                         self.train_writer.add_summary(outputs.get(self.summaries), global_step)
@@ -246,9 +247,9 @@ class BaseModel(object, metaclass=ABCMeta):
                             feed_dict[self.Y] = yval
 
                         outputs = self._eval(self.target_loss, self.summaries, feed_dict=feed_dict)
-
                         if self.valid_writer is not None:
                             self.valid_writer.add_summary(outputs.get(self.summaries), global_step)
+
                         val_cost = outputs.get(self.target_loss, 0)
                         sum_val_loss += val_cost
 

--- a/finetune/datasets/stanford_sentiment_treebank.py
+++ b/finetune/datasets/stanford_sentiment_treebank.py
@@ -41,7 +41,7 @@ class StanfordSentimentTreebank(Dataset):
 if __name__ == "__main__":
     # Train and evaluate on SST
     dataset = StanfordSentimentTreebank(nrows=1000).dataframe
-    model = Classifier(verbose=True, n_epochs=2, val_size=0.01, val_interval=10, visible_gpus=[])
+    model = Classifier(verbose=True, n_epochs=2, val_size=0.01, val_interval=10, visible_gpus=[], tensorboard_folder='.tensorboard')
     trainX, testX, trainY, testY = train_test_split(dataset.Text, dataset.Target, test_size=0.3, random_state=42)
     model.fit(trainX, trainY)
     accuracy = np.mean(model.predict(testX) == testY)


### PR DESCRIPTION
Little conflicted on this -- we can't run this automatically because we don't know what directory people are going to write tensorboard summaries to.  This exposes the port but tensorboard still has to be run internally to the docker container.  The only thing it prevents is having to install tensorflow on your host machine (slash make sure versions match up).