### PR TITLE
setup: add TF as extra-requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,9 @@ setup(
     packages=find_packages(),
     version="0.5.10",
     install_requires=REQUIREMENTS,
+    extras_require={
+        "tf": ["tensorflow"],
+        "tf_gpu": ["tensorflow-gpu"],
+    },
     include_package_data=False
 )

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ setup(
     version="0.5.10",
     install_requires=REQUIREMENTS,
     extras_require={
-        "tf": ["tensorflow"],
-        "tf_gpu": ["tensorflow-gpu"],
+        "tf": ["tensorflow>=1.11.0"],
+        "tf_gpu": ["tensorflow-gpu>=1.11.0"],
     },
     include_package_data=False
 )


### PR DESCRIPTION
This would allow the user to specify explicitly which version of TF
is needed. E.g. `finetune[tf_gpu]`.

See this discussion for details:
https://github.com/tensorflow/tensorflow/issues/7166

Signed-off-by: Dimid Duchovny <dimidd@gmail.com>