### PR TITLE
setup: remove Indico from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pandas>=0.23.1
-IndicoIo>=1.1.5
 tqdm>=4.0.0
 numpy>=1.15.0
 scipy>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ from setuptools import setup, find_packages
 
 REQUIREMENTS = [
     "pandas>=0.23.1",
-    "IndicoIo>=1.1.5",
     "tqdm>=4.0.0",
     "numpy>=1.13.0",
     "scipy>=1.1.0",


### PR DESCRIPTION
Unless I'm missing something, looks like `IndicoIo` is never imported.
Could we remove it as a requirement?

Signed-off-by: Dimid Duchovny <dimidd@gmail.com>