### PR TITLE
Fix label mapping when oversampling

### DIFF
--- a/finetune/classifier.py
+++ b/finetune/classifier.py
@@ -13,7 +13,7 @@ class ClassificationPipeline(BasePipeline):
     def resampling(self, Xs, Y):
         if self.config.oversample:
             idxs, Ys = RandomOverSampler().fit_sample([[i] for i in range(len(Xs))], Y)
-            return [Xs[i[0]] for i in idxs], [Ys[i[0]] for i in idxs]
+            return [Xs[i[0]] for i in idxs], Ys
         return Xs, Y
 
     def _target_encoder(self):


### PR DESCRIPTION
I've been checking if this actually caused wrong labels and it probably
doesn't, since the new duplicated samples seem to be added after the
original ones, so idxs[0:len(Xs))] should actually the same as range(len(Xs)).

I found this because I was doing undersampling instead and copying your oversampling code - which works the same way except that it shows this bug.

Fixes #186