### PR TITLE
ADD: base: pass estimator to predict

### DIFF
--- a/finetune/base.py
+++ b/finetune/base.py
@@ -211,8 +211,9 @@ class BaseModel(object, metaclass=ABCMeta):
             params=self.config
         )
 
-    def _inference(self, Xs, mode=None):
-        estimator = self.get_estimator()
+    def _inference(self, Xs, mode=None, estimator=None):
+        if estimator is None:
+            estimator = self.get_estimator()
         input_func = self.input_pipeline.get_predict_input_fn(Xs)
         length = len(Xs) if not callable(Xs) else None
 
@@ -234,18 +235,18 @@ class BaseModel(object, metaclass=ABCMeta):
         """ An alias for finetune. """
         return self.finetune(*args, **kwargs)
 
-    def _predict(self, Xs):
+    def _predict(self, Xs, estimator=None):
         raw_preds = self._inference(Xs, PredictMode.NORMAL)
         return self.input_pipeline.label_encoder.inverse_transform(np.asarray(raw_preds))
 
-    def predict(self, Xs):
-        return self._predict(Xs)
+    def predict(self, Xs, estimator=None):
+        return self._predict(Xs, estimator)
 
-    def _predict_proba(self, Xs):
+    def _predict_proba(self, Xs, estimator=None):
         """
         Produce raw numeric outputs for proba predictions
         """
-        raw_preds = self._inference(Xs, PredictMode.PROBAS)
+        raw_preds = self._inference(Xs, PredictMode.PROBAS, estimator)
         return raw_preds
 
     def predict_proba(self, *args, **kwargs):

--- a/finetune/classifier.py
+++ b/finetune/classifier.py
@@ -40,23 +40,25 @@ class Classifier(BaseModel):
         """
         return super().featurize(X)
 
-    def predict(self, X):
+    def predict(self, X, estimator=None):
         """
         Produces a list of most likely class labels as determined by the fine-tuned model.
 
         :param X: list or array of text to embed.
+        :param estimator: TensorFlow estimator.
         :returns: list of class labels.
         """
-        return super().predict(X)
+        return super().predict(X, estimator)
 
-    def predict_proba(self, X):
+    def predict_proba(self, X, estimator=None):
         """
         Produces a probability distribution over classes for each example in X.
 
         :param X: list or array of text to embed.
+        :param estimator: TensorFlow estimator.
         :returns: list of dictionaries.  Each dictionary maps from a class label to its assigned class probability.
         """
-        return super().predict_proba(X)
+        return super().predict_proba(X, estimator)
 
     def finetune(self, X, Y=None, batch_size=None):
         """


### PR DESCRIPTION
Allow to optionally pass an estimator to `predict`, and `predict_proba`,
in order to call `get_estimator` just once in subsequent `predict` calls.

Signed-off-by: Dimid Duchovny <dimidd@gmail.com>