### PR TITLE
FIX: ability to turn off early stopping entirely

### DIFF
--- a/finetune/config.py
+++ b/finetune/config.py
@@ -189,7 +189,7 @@ def get_default_config():
         multi_label_threshold=0.5,
         autosave_path=None,
         keep_best_model=False,
-        early_stopping_steps=100,
+        early_stopping_steps=None,
         tensorboard_folder=None,
         shuffle_buffer_size=100,
         min_secs_between_eval=60,

--- a/finetune/saver.py
+++ b/finetune/saver.py
@@ -2,6 +2,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 import itertools
 import logging
+import sys
 
 import joblib
 import numpy as np
@@ -22,7 +23,7 @@ class SaverHook(_StopOnPredicateHook):
         self.included = None
         self.saver = saver
         self.keep_best_model = keep_best_model
-        self.early_stopping_steps = early_stopping_steps
+        self.early_stopping_steps = early_stopping_steps or sys.maxsize
         self.steps_per_epoch = steps_per_epoch
         self.estimator = estimator
 


### PR DESCRIPTION
Early stopping default was 100 steps of no improvement. This is now off by default.