### PR TITLE
FIX: deployment model initialisation

### DIFF
--- a/finetune/target_models/deployment_model.py
+++ b/finetune/target_models/deployment_model.py
@@ -134,8 +134,7 @@ class DeploymentModel(BaseModel):
         if "base_model" in kwargs:
             if featurizer and kwargs["base_model"] != featurizer:
                 raise FinetuneError("Base model passed in config does not match featurizer argument")
-            if not featurizer:
-                featurizer = kwargs["base_model"]
+            featurizer = kwargs.pop("base_model")
 
         super().__init__(base_model=featurizer, **kwargs)
         if featurizer.featurizer not in [gpt2_featurizer, gpt_featurizer, bert_featurizer]:

--- a/finetune/target_models/deployment_model.py
+++ b/finetune/target_models/deployment_model.py
@@ -134,6 +134,9 @@ class DeploymentModel(BaseModel):
         if "base_model" in kwargs:
             if featurizer and kwargs["base_model"] != featurizer:
                 raise FinetuneError("Base model passed in config does not match featurizer argument")
+            if not featurizer:
+                featurizer = kwargs["base_model"]
+
         super().__init__(base_model=featurizer, **kwargs)
         if featurizer.featurizer not in [gpt2_featurizer, gpt_featurizer, bert_featurizer]:
             raise FinetuneError("Selected base model not supported.")

--- a/tests/test_deployment_model.py
+++ b/tests/test_deployment_model.py
@@ -175,7 +175,6 @@ class TestDeploymentModel(unittest.TestCase):
             'max_length': 256,
             'n_epochs': 3,
             'adapter_size': 64,
-            'base_model': cls.base_model,
             'chunk_long_sequences': False
         }
         defaults.update(kwargs)
@@ -201,7 +200,6 @@ class TestDeploymentModel(unittest.TestCase):
             n_epochs=1,
             l2_reg=0,
             lm_loss_coef=0.,
-            base_model=cls.base_model,
             val_size=0.,
         )
         d.update(kwargs)


### PR DESCRIPTION
proposed fix for #375 

For a bit of context it seems like the bug was that it expected the config `base_model`  to match the featurizer argument. I have removed this redundancy and updated the tests which were reinforcing this behaviour.