### PR TITLE
ADD: make models serializable to file like objects

### DIFF
--- a/finetune/base.py
+++ b/finetune/base.py
@@ -610,8 +610,9 @@ class BaseModel(object, metaclass=ABCMeta):
         """
         if path is None:
             return
-
-        path = os.path.abspath(path)
+        
+        if isinstance(path, str):
+            path = os.path.abspath(path)
         self.saver.save(self, path)
 
     def create_base_model(self, filename, exists_ok=False):
@@ -648,7 +649,7 @@ class BaseModel(object, metaclass=ABCMeta):
         :param path: string path name to load model from.  Same value as previously provided to :meth:`save`. Must be a folder.
         :param **kwargs: key-value pairs of config items to override.
         """
-        if type(path) != str:
+        if type(path) != str and not hasattr(path, "write"):
             instance = path
             raise FinetuneError(
                 'The .load() method can only be called on the class, not on an instance. Try `{}.load("{}") instead.'.format(

--- a/finetune/base_models/textcnn/model.py
+++ b/finetune/base_models/textcnn/model.py
@@ -19,6 +19,7 @@ class TextCNNModel(SourceModel):
         "n_epochs": 100,
         "keep_best_model": True,
         "early_stopping_steps": 100,
+        "val_size": "auto"
         "num_layers_trained": 1,
         "kernel_sizes": kernel_sizes,
         "num_filters_per_size": 2,

--- a/finetune/base_models/textcnn/model.py
+++ b/finetune/base_models/textcnn/model.py
@@ -19,7 +19,7 @@ class TextCNNModel(SourceModel):
         "n_epochs": 100,
         "keep_best_model": True,
         "early_stopping_steps": 100,
-        "val_size": "auto"
+        "val_size": "auto",
         "num_layers_trained": 1,
         "kernel_sizes": kernel_sizes,
         "num_filters_per_size": 2,

--- a/finetune/saver.py
+++ b/finetune/saver.py
@@ -212,9 +212,10 @@ class Saver:
             variables = self.variables
 
         names, values = variables.keys(), variables.values()
-        folder = os.path.dirname(path)
-        if not os.path.exists(folder) and mkdir:
-            os.mkdir(folder)
+        if isinstance(path, str):
+            folder = os.path.dirname(path)
+            if not os.path.exists(folder) and mkdir:
+                os.mkdir(folder)
         if self.save_dtype is not None:
             LOGGER.info("Saving with {} precision.".format(self.save_dtype.__name__))
             values = [a.astype(self.save_dtype) for a in values]

--- a/finetune/saver.py
+++ b/finetune/saver.py
@@ -214,8 +214,7 @@ class Saver:
         names, values = variables.keys(), variables.values()
         if isinstance(path, str):
             folder = os.path.dirname(path)
-            if not os.path.exists(folder) and mkdir:
-                os.mkdir(folder)
+            os.makedirs(folder, exist_ok=True)
         if self.save_dtype is not None:
             LOGGER.info("Saving with {} precision.".format(self.save_dtype.__name__))
             values = [a.astype(self.save_dtype) for a in values]


### PR DESCRIPTION
A compromise for serialisation that allows you to write to file like objects.
this means to save a list of finetune objects you can save them to a single file by
```
outputs = []
for model in models:
    f = io.BytesIO()
    model.save(f)
    f.seek(0)
    outputs.append(f)
jl.dump(outputs, file)
```
and to load just 
```
models = []
for f in jl.load(file):
    models.append(Classifier.load(f))
```
