### PR TITLE
Lily/mlm pretraining feat

### DIFF
--- a/finetune/base_models/bert/featurizer.py
+++ b/finetune/base_models/bert/featurizer.py
@@ -33,6 +33,9 @@ def bert_featurizer(
     is_roberta = issubclass(config.base_model.encoder, RoBERTaEncoder)
     is_roberta_v1 = is_roberta and not config.base_model_path.endswith("roberta-model-sm-v2.jl")
 
+    print('config.use_auxiliary_info and not config.mlm_baseline', config.use_auxiliary_info and not config.mlm_baseline)
+    print('config.mlm_baseline', config.mlm_baseline)
+    print('config.use_auxiliary_info', config.use_auxiliary_info)
     bert_config = BertConfig(
         vocab_size=encoder.vocab_size,
         hidden_size=config.n_embed,

--- a/finetune/base_models/bert/modeling.py
+++ b/finetune/base_models/bert/modeling.py
@@ -173,6 +173,8 @@ class BertModel(object):
         if not is_training:
             config.hidden_dropout_prob = 0.0
             config.attention_probs_dropout_prob = 0.0
+        
+        print('***config.use_auxiliary_info:', config.use_auxiliary_info)
 
         input_shape = get_shape_list(input_ids, expected_rank=2)
         batch_size = input_shape[0]
@@ -218,7 +220,7 @@ class BertModel(object):
 
                 # Run the stacked transformer.
                 # `sequence_output` shape = [batch_size, seq_length, hidden_size].
-                if context is not None:
+                if context is not None and config.use_auxiliary_info:
                     hidden_and_auxiliary_dim = config.hidden_size + config.n_context_embed_per_channel * config.context_dim
                     self.all_encoder_layers = transformer_model(
                         input_tensor=tf.concat((self.embedding_output, context), -1),
@@ -894,7 +896,6 @@ def full_block(
             intermediate_output,
             hidden_size,
             activation=None,
-            name="compress_to_hidden",
             kernel_initializer=create_initializer(initializer_range),
             custom=config.use_auxiliary_info,
             pos_embed=config.n_context_embed_per_channel*config.context_dim)

--- a/finetune/base_models/bert/modeling.py
+++ b/finetune/base_models/bert/modeling.py
@@ -866,7 +866,6 @@ def full_block(
                 attention_output,
                 hidden_size,
                 activation=None,
-                name="attention",
                 kernel_initializer=create_initializer(initializer_range),
                 custom=config.use_auxiliary_info,
                 pos_embed=config.n_context_embed_per_channel*config.context_dim)
@@ -885,7 +884,6 @@ def full_block(
             attention_output,
             intermediate_size,
             activation=intermediate_act_fn,
-            name="intermediate",
             kernel_initializer=create_initializer(initializer_range),
             custom=config.use_auxiliary_info,
             pos_embed=config.n_context_embed_per_channel*config.context_dim)

--- a/finetune/base_models/bert/modeling.py
+++ b/finetune/base_models/bert/modeling.py
@@ -173,8 +173,6 @@ class BertModel(object):
         if not is_training:
             config.hidden_dropout_prob = 0.0
             config.attention_probs_dropout_prob = 0.0
-        
-        print('***config.use_auxiliary_info:', config.use_auxiliary_info)
 
         input_shape = get_shape_list(input_ids, expected_rank=2)
         batch_size = input_shape[0]


### PR DESCRIPTION
1. Fixes the config logic so that mlm_baseline runs again without error
2. Removes extraneous names in the dense_with_custom_init calls
3. Accounts for additional pos info in increasing num_attention_heads