### PR TITLE
FIX: do not add newline to last page of text

### DIFF
--- a/finetune/target_models/document_labeling.py
+++ b/finetune/target_models/document_labeling.py
@@ -1,5 +1,6 @@
 from finetune.target_models.sequence_labeling import SequenceLabeler, SequencePipeline
 from finetune.encoding.input_encoder import EncodedOutput
+from finetune.errors import FinetuneError
 
 def get_context(document, dpi_norm):
     """
@@ -38,9 +39,13 @@ def _single_convert_to_finetune(*, document, dpi_norm=True):
     texts = []
     offsets = []
     last_end = -1
-    for page in document:
+    num_pages = len(document)
+    for i, page in enumerate(document):
         page_obj = page["pages"][0]
-        texts.append(page_obj["text"] + "\n")
+        if i == num_pages - 1:
+            texts.append(page_obj["text"])
+        else:
+            texts.append(page_obj["text"] + "\n")
         offset = page_obj["doc_offset"]
         assert offset["start"] == last_end + 1, "If ever this ceases to hold then we have a problem"
         last_end = offset["end"]

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -88,3 +88,10 @@ class TestDocumentLabeler(unittest.TestCase):
         baseline_model_f1 = sequence_labeling_micro_token_f1(test_labels, baseline_model_preds)
         self.assertGreater(model_f1, baseline_model_f1)
         self.assertGreater(model_f1, 0.95)
+
+    def test_featurize_doc_with_empty_pages(self):
+        """ Test that context alignment with tokenization doesn't error out """
+        with open('tests/data/doc_with_empty_pages.json') as f:
+            doc = json.load(f)
+        model = DocumentLabeler(n_epochs=20, base_model=DocRep, crf_sequence_labeling=True)
+        model.featurize([doc])


### PR DESCRIPTION
Explanation for the bug and the fix:
With DocumentLabeler, we add a newline to the end of each page. These newlines don't have corresponding context, but tokenization gives it the same token_start as the token_end of the previous token and a length of 0. Therefore, the token_end of the newline token is the same as that of the previous token on the page, which means it gets assigned the same position context info. When you go to a new page though, we increment the index, so in the case of an empty page as the last page in the doc, the newline has an index past the end index in the context. 