### PR TITLE
Change the no label default text from "<PAD>" to be more descriptive

### DIFF
--- a/finetune/config.py
+++ b/finetune/config.py
@@ -260,7 +260,7 @@ def get_default_config():
 
         # Sequence Labeling
         seq_num_heads=16,
-        pad_token="<PAD>",
+        pad_token="<NO_LABEL>",
         pad_idx=None,
         subtoken_predictions=False,
         multi_label_sequences=False,


### PR DESCRIPTION
Changed the default config variable for pad_token from PAD to "<NO_LABEL>"