### PR TITLE
ADD: Make text in context optional

### DIFF
--- a/finetune/encoding/input_encoder.py
+++ b/finetune/encoding/input_encoder.py
@@ -229,7 +229,7 @@ def tokenize_context(context, encoded_output, config):
 #        context = get_relevant_context_for_chunk(context, encoded_output)
     seq_len = len(encoded_output.token_ids)
     context_keys = list(k for k in sorted(context[0].keys()) if k not in INFO_KEYS)
-    context_by_char_loc = sorted([(c['end'], [c[k] for k in context_keys], c["text"]) for c in context], key=lambda c: c[0])
+    context_by_char_loc = sorted([(c['end'], [c[k] for k in context_keys], c.get("text")) for c in context], key=lambda c: c[0])
     # default context is set by user in config
     default_context = [config.default_context[k] for k in context_keys]
     current_char_loc = 0
@@ -246,7 +246,7 @@ def tokenize_context(context, encoded_output, config):
                 current_char_loc += 1
                 if current_char_loc >= len(context_by_char_loc):
                     raise ValueError("Context cannot be fully matched as it appears to not cover the end of the sequence for token {}".format(token))
-            if token.strip() not in context_by_char_loc[current_char_loc][2]:
+            if context_by_char_loc[current_char_loc][2] and token.strip() not in context_by_char_loc[current_char_loc][2]:
                 warnings.warn("subtoken: {} has matched up with the context for token: {}".format(repr(token), repr(context_by_char_loc[current_char_loc][2])))
             tokenized_context.append(context_by_char_loc[current_char_loc][1])
 


### PR DESCRIPTION
I'm not even sure if this is desired behaviour, but some of the enso datasets don't have text in the context so I've been applying this patch on and off every time I run something.