### PR TITLE
ADD: Ability to pre chunk sequences during prediction

### DIFF
--- a/finetune/config.py
+++ b/finetune/config.py
@@ -63,7 +63,7 @@ class Settings(dict):
         (unless `chunk_long_sequences=True` for SequenceLabeler models). Defaults to `512`.
     :param weight_stddev: Standard deviation of initial weights.  Defaults to `0.02`.
     :param chunk_long_sequences: When True, use a sliding window approach to predict on
-        examples that are longer than max length.  The progress bar will display the number of chunks processed rather than the number of examples. Defaults to `True`.  
+        examples that are longer than max length.  The progress bar will display the number of chunks processed rather than the number of examples. Defaults to `True`.
     :param use_gpu_crf_predict: Use GPU op for crf predictions. Defaults to `auto`.
         examples that are longer than max length.  The progress bar will display the number of chunks processed rather than the number of examples. Defaults to `True`.
     :param chunk_context: How much context to include arround chunked text.
@@ -87,7 +87,7 @@ class Settings(dict):
     :param lr_warmup: Learning rate warmup (percentage of all batches to warmup for).  Defaults to `0.002`.
     :param max_grad_norm: Clip gradients larger than this norm. Defaults to `1.0`.
     :param shuffle_buffer_size: How many examples to load into a buffer before shuffling. Defaults to `100`.
-    :param dataset_size: Must be specified in order to calculate the learning rate schedule when the inputs provided are generators rather than static datasets.  
+    :param dataset_size: Must be specified in order to calculate the learning rate schedule when the inputs provided are generators rather than static datasets.
     :param accum_steps: Number of updates to accumulate before applying. This is used to simulate a higher batch size.
     :param lm_loss_coef: Language modeling loss coefficient -- a value between `0.0` - `1.0`
         that indicates how to trade off between language modeling loss
@@ -123,7 +123,11 @@ class Settings(dict):
     :param val_set: Where it is neccessary to use an explicit validation set, provide it here as a tuple (text, labels)
     :param per_process_gpu_memory_fraction: fraction of the overall amount of memory that each visible GPU should be allocated, defaults to `1.0`.
     :param max_empty_chunk_ratio: Controls the maximum ratio of empty to labeled chunks for sequence labeling. None includes all chunks, defaults to 1.0.
-
+    :param auto_negative_sampling: Method to use with long sparse documents to cut down on training
+        time and limit false positives. Defaults to False
+    :param max_document_chars: Maximum number of characters in a document before splitting into
+        len(document) / max_document_chars "sub documents" for prediction to avoid memory issues
+        during creation of the input pipeline. Defaults to None (no splitting)
     """
 
     def get_grid_searchable(self):
@@ -277,6 +281,7 @@ def get_default_config():
         use_gpu_crf_predict="auto",
         max_empty_chunk_ratio=1.0,
         auto_negative_sampling=False,
+        max_document_chars=None,
         #
         # Regression Params
         regression_loss="L2",
@@ -343,7 +348,7 @@ def get_config(error_on_invalid_keywords=True, **kwargs):
     Gets a config object containing all the default parameters for each variant of the model.
 
     :param **kwargs: Keyword arguments to override default values.
-    :return: Config object.    """
+    :return: Config object."""
     if error_on_invalid_keywords:
         assert_valid_config(**kwargs)
     config = get_default_config()

--- a/finetune/target_models/sequence_labeling.py
+++ b/finetune/target_models/sequence_labeling.py
@@ -1,6 +1,7 @@
 import itertools
 import copy
 from collections import Counter
+import math
 from typing import Dict, List, Tuple
 
 import tensorflow as tf
@@ -255,7 +256,7 @@ class SequenceLabeler(BaseModel):
         # Split documents into "sub documents" if any are too long
         for doc_idx, doc in enumerate(texts):
             if len(doc) > max_doc_len:
-                num_splits = int(len(doc) // max_doc_len) + 1
+                num_splits = math.ceil(len(doc) / max_doc_len)
                 for split_idx in range(num_splits):
                     new_texts.append(doc[split_idx * max_doc_len: (split_idx + 1) * max_doc_len])
                 split_indices.append(list(range(doc_idx + offset, doc_idx + offset + num_splits)))

--- a/finetune/target_models/sequence_labeling.py
+++ b/finetune/target_models/sequence_labeling.py
@@ -1,6 +1,7 @@
 import itertools
 import copy
 from collections import Counter
+from typing import Dict, List, Tuple
 
 import tensorflow as tf
 import numpy as np
@@ -234,6 +235,73 @@ class SequenceLabeler(BaseModel):
             self._initialize()
         return super().finetune(Xs, Y=Y, context=context, update_hook=update_hook)
 
+    def _pre_chunk_document(self, texts: List[str]) -> Tuple[List[str], List[List[int]]]:
+        """
+        If self.config.max_document_chars is set, "pre-chunk" any documents that
+        are longer than that into multiple "sub documents" to more easily process
+        large documents through prediction.
+
+        Args:
+            texts: Text of each document
+
+        Returns:
+            new_texts: Text of each document after pre chunking
+            split_indices: Indices of documents that were split by pre chunking
+        """
+        max_doc_len = self.config.max_document_chars
+        new_texts = []
+        split_indices = []
+        offset = 0
+        # Split documents into "sub documents" if any are too long
+        for doc_idx, doc in enumerate(texts):
+            if len(doc) > max_doc_len:
+                num_splits = int(len(doc) // max_doc_len) + 1
+                for split_idx in range(num_splits):
+                    new_texts.append(doc[split_idx * max_doc_len: (split_idx + 1) * max_doc_len])
+                split_indices.append(list(range(doc_idx + offset, doc_idx + offset + num_splits)))
+                offset += num_splits - 1
+            else:
+                new_texts.append(doc)
+                split_indices.append([doc_idx + offset])
+
+        return new_texts, split_indices
+
+    def _merge_chunked_preds(self, preds: List[Dict], split_indices: List[List[int]]) -> List[Dict]:
+        """
+        If self.config.max_document_chars is set, text for long documents is split
+        into multiple "sub documents". Given model predictions, and the indices
+        specifying which documents have been split, join the labels for previously
+        split documents together.
+
+        Args:
+            preds: Model predictions
+            split_indices: Indices specifying how documents were split
+
+        Returns:
+            merged_preds: Model predictions after merging documents together
+        """
+        merged_preds = []
+        for pred_idxs in split_indices:
+            if len(pred_idxs) == 1:
+                merged_preds.append(preds[pred_idxs[0]])
+            else:
+                # len(pred_idxs) > 1 indicates that a document was split into multiple
+                # "sub documents", for which the labels need to be merged
+                doc_preds = []
+                for chunk_idx, pred_idx in enumerate(pred_idxs):
+                    offset = chunk_idx * self.config.max_document_chars
+                    chunk_preds = preds[pred_idx]
+                    # Add offset to label start/ends so that they index correctly
+                    # into the text after joining across pre chunks
+                    for i in range(len(chunk_preds)):
+                        chunk_preds[i]["start"] += offset
+                        chunk_preds[i]["end"] += offset
+                    doc_preds.extend(chunk_preds)
+
+                merged_preds.append(doc_preds)
+
+        return merged_preds
+
     def predict(
         self, X, per_token=False, context=None, return_negative_confidence=False, **kwargs
     ):
@@ -244,13 +312,24 @@ class SequenceLabeler(BaseModel):
         :param per_token: If True, return raw probabilities and labels on a per token basis
         :returns: list of class labels.
         """
-        return super().predict(
+        if self.config.max_document_chars:
+            # Split each document into N "pre chunks" or length self.config.max_document_chars
+            # before feeding them into the input pipeline. The split_indices will be used to
+            # rejoin the labels after prediction
+            X, split_indices = self._pre_chunk_document(X)
+
+        preds = super().predict(
             X,
             per_token=per_token,
             context=context,
             return_negative_confidence=return_negative_confidence,
             **kwargs
         )
+
+        if self.config.max_document_chars:
+            preds = self._merge_chunked_preds(preds, split_indices)
+
+        return preds
 
     def _predict(
         self, zipped_data, per_token=False, return_negative_confidence=False, **kwargs

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 import logging
-from copy import copy
+from copy import copy, deepcopy
 from pathlib import Path
 import codecs
 import json
@@ -81,10 +81,8 @@ class TestSequenceLabeler(unittest.TestCase):
             docs.append(texts)
             docs_labels.append(labels)
 
-
         with open(cls.processed_path, 'wt') as fp:
             json.dump((docs, docs_labels), fp)
-
 
     @classmethod
     def setUpClass(cls):
@@ -191,7 +189,6 @@ class TestSequenceLabeler(unittest.TestCase):
 
         self.assertGreater(reweighted_token_recall['Named Entity'], token_recall['Named Entity'])
 
-
     def test_cached_predict(self):
         """
         Ensure model training does not error out
@@ -202,7 +199,7 @@ class TestSequenceLabeler(unittest.TestCase):
                                                          none_value=self.model.config.pad_token)
         train_texts, test_texts, train_annotations, _ = train_test_split(texts, annotations, test_size=0.1)
         self.model.fit(train_texts, train_annotations)
-        
+
         self.model.config.chunk_long_sequences = True
         self.model.config.max_length = 128
 
@@ -231,7 +228,6 @@ class TestSequenceLabeler(unittest.TestCase):
     def test_raises_when_text_doesnt_match(self):
         with self.assertRaises(ValueError):
             self.model.fit(["Text about a dog."], [[{"start": 0, "end": 5, "text": "cat", "label": "dog"}]])
-
 
     def test_reasonable_predictions(self):
         test_sequence = ["I am a dog. A dog that's incredibly bright. I can talk, read, and write!"]
@@ -267,7 +263,6 @@ class TestSequenceLabeler(unittest.TestCase):
         predictions = self.model.predict(test_sequence)
         self.assertEqual(len(predictions[0]), 20)
         self.assertTrue(any(pred["text"].strip() == "dog" for pred in predictions[0]))
-        
 
     def test_fit_predict_multi_model(self):
         """
@@ -290,7 +285,6 @@ class TestSequenceLabeler(unittest.TestCase):
         model = SequenceLabeler.load(self.save_file)
         model.predict(test_texts)
 
-
     def test_pred_alignment(self):
         model = SequenceLabeler(subtoken_predictions=True)
         text = "John J Johnson"
@@ -300,7 +294,6 @@ class TestSequenceLabeler(unittest.TestCase):
         self.assertEqual(len(preds), 1)
         del preds[0]["confidence"]
         self.assertEquals(preds, labels)
-
 
     def test_auto_negative_chunks(self):
         raw_docs = ["".join(text) for text in self.texts]
@@ -320,6 +313,80 @@ class TestSequenceLabeler(unittest.TestCase):
         baseline_token_precision = sequence_labeling_token_precision(test_annotations, baseline_predictions)
 
         assert ans_token_precision['Named Entity'] > baseline_token_precision['Named Entity']
+
+    def test_pre_chunking(self):
+        """
+        If config.max_document_chars is set, documents are "pre chunked" into "sub
+        documents" prior to creation of the input pipeline. This test asserts that
+        the splitting and rejoining behaves as expected.
+        """
+        max_doc_len = 250
+
+        # Create a mix of short and long sequences for prediction
+        test_sequence = "I am a dog. A dog that's incredibly bright. I can talk, read, and write! "
+        test_sequences = [test_sequence, test_sequence * 10, test_sequence, test_sequence * 10]
+
+        # Use animal test data to train model
+        path = os.path.join(os.path.dirname(__file__), "data", "testdata.json")
+        with open(path, "rt") as fp:
+            text, labels = json.load(fp)
+        self.model.finetune(text * 10, labels * 10)
+
+        # Split inputs into "sub documents"
+        self.model.config.max_document_chars = max_doc_len
+        split_sequences, split_indices = self.model._pre_chunk_document(test_sequences)
+
+        # Predict on the newly split sequences. We unset config.max_document chars
+        # prior to calling predict so that we don't repeat the pre chunking that we
+        # did explicitly above. This has the potential to be brittle if the functionality
+        # of predict in sequence_labeler.py changes
+        self.model.config.max_document_chars = None
+        split_preds = self.model.predict(split_sequences)
+
+        # Rejoin predictions using split_indices
+        self.model.config.max_document_chars = max_doc_len
+        preds = self.model._merge_chunked_preds(deepcopy(split_preds), split_indices)
+
+        # Assert that documents were split properly
+        assert split_indices == [[0], [1, 2, 3], [4], [5, 6, 7]]
+        assert len(split_preds) == 8
+        assert len(preds) == 4
+
+        # Assert that the offset is calculated correctly for start/end indices after
+        # merging predictions by specifically looking at the last "sub document" of
+        # second (index 1) document, which was split into three "sub documents"
+        sub_split_preds = split_preds[3]
+        sub_preds = [pred for pred in preds[1] if pred["start"] >= max_doc_len * 2]
+        for split_pred, pred in zip(sub_split_preds, sub_preds):
+            assert split_pred["start"] + max_doc_len * 2 == pred["start"]
+            assert split_pred["end"] + max_doc_len * 2 == pred["end"]
+
+    def test_max_document_chars(self):
+        """
+        If documents are "pre chunked" due to config.max_document_chars being set,
+        predictions are impacted when a document is split in the middle of a non-pad
+        token. This test asserts that the impact is minimal.
+        """
+        # Use animal test data to train model
+        test_sequence = ["I am a dog. A dog that's incredibly bright. I can talk, read, and write! " * 10]
+        path = os.path.join(os.path.dirname(__file__), "data", "testdata.json")
+        with open(path, "rt") as fp:
+            text, labels = json.load(fp)
+        self.model.finetune(text * 10, labels * 10)
+
+        # Predict without config.max_document_chars
+        preds = self.model.predict(test_sequence)
+
+        # Predict with config.max_document_chars set to split long sequence
+        self.model.config.max_document_chars = 250
+        pre_chunk_preds = self.model.predict(test_sequence)
+
+        # Ensure that the number of predictions of the span "dog" is almost identical
+        # between preds and pre_chunk_preds. The reason these values are not identical
+        # is because with pre chunking, "dog" can be split across multiple sub documents
+        num_dog_preds = len([p for p in preds[0] if p["text"] == "dog"])
+        num_dog_pre_chunk_preds = len([p for p in pre_chunk_preds[0] if p["text"] == "dog"])
+        assert num_dog_pre_chunk_preds / num_dog_preds >= 0.95
 
 
 class TestSequenceMemoryLeak(unittest.TestCase):
@@ -351,7 +418,6 @@ class TestSequenceMemoryLeak(unittest.TestCase):
                 except Exception as e:
                     print(e)
         return weakrefs
-
 
     def test_leaking_objects(self):
         previous_model_wrs = None


### PR DESCRIPTION
This commit adds the ability to pre chunk documents into "sub documents" prior to creation of the input pipeline during prediction for the sequence labeler target model by setting config.max_document_chars. The purpose is to prevent memory issues for very long documents.