### PR TITLE
Eamon/fixed whitespace

### DIFF
--- a/finetune/encoding/input_encoder.py
+++ b/finetune/encoding/input_encoder.py
@@ -66,7 +66,7 @@ def _remove_repeated_whitespace(encoded):
         encoded.token_ids, encoded.tokens, encoded.token_ends, encoded.token_starts
     ):
         mask = [
-            i != 0 and token.strip() == tokens[i - 1].strip() == "" for i, token in enumerate(tokens)
+            i != 0 and token.strip(" ") == tokens[i - 1].strip(" ") == "" for i, token in enumerate(tokens)
         ]
         batch_token_idxs.append([x for x, c in zip(token_ids, mask) if not c])
         batch_tokens.append([x for x, c in zip(tokens, mask) if not c])

--- a/finetune/encoding/input_encoder.py
+++ b/finetune/encoding/input_encoder.py
@@ -66,7 +66,7 @@ def _remove_repeated_whitespace(encoded):
         encoded.token_ids, encoded.tokens, encoded.token_ends, encoded.token_starts
     ):
         mask = [
-            i != 0 and token == tokens[i - 1] == " " for i, token in enumerate(tokens)
+            i != 0 and token.strip() == tokens[i - 1].strip() == "" for i, token in enumerate(tokens)
         ]
         batch_token_idxs.append([x for x, c in zip(token_ids, mask) if not c])
         batch_tokens.append([x for x, c in zip(tokens, mask) if not c])

--- a/finetune/input_pipeline.py
+++ b/finetune/input_pipeline.py
@@ -413,6 +413,7 @@ class BasePipeline(metaclass=ABCMeta):
         else:
             encoder_out = self.text_encoder.encode_multi_input(
                 Xs, max_length=self.config.max_length,
+                remove_repeated_whitespace=self.config.collapse_whitespace,
             )
 
             d = dict()


### PR DESCRIPTION
Fast tokenizers produce an empty string (`""`) instead of a single space (`" "`) for whitespace.
Update the `remove_repeated_whitespace` function to support either behavior.