### PR TITLE
FIX: Remove whitespace from start and end of predictions

### DIFF
--- a/finetune/encoding/sequence_encoder.py
+++ b/finetune/encoding/sequence_encoder.py
@@ -296,7 +296,7 @@ def strip_annotation_whitespace(annotation):
     r_pad = len(l_strip) - len(lr_strip)
 
     annotation["text"] = lr_strip
-    annotation["start"] -= l_pad
-    annotation["end"] -= l_pad + r_pad
+    annotation["start"] += l_pad
+    annotation["end"] -= r_pad
 
     return annotation

--- a/finetune/encoding/sequence_encoder.py
+++ b/finetune/encoding/sequence_encoder.py
@@ -170,6 +170,9 @@ def finetune_to_indico_sequence(
                     "text": raw_text[annotation_start:annotation_end],
                 }
 
+                if annotation["text"].strip() != annotation["text"]:
+                    annotation = strip_annotation_whitespace(annotation)
+
                 # if we don't want to allow subtoken predictions, adjust start and end to match
                 # the start and ends of the nearest full tokens
                 if not subtoken_predictions:
@@ -284,3 +287,16 @@ def overlap_handler(current_annotation, annotation, text, multi_label):
     chunks = [first_chunk, second_chunk, third_chunk]
     chunks = [c for c in chunks if c["start"] != c["end"]]
     return chunks
+
+def strip_annotation_whitespace(annotation):
+    text = annotation["text"]
+    l_strip = text.lstrip()
+    l_pad = len(text) - len(l_strip)
+    lr_strip = l_strip.rstrip()
+    r_pad = len(l_strip) - len(lr_strip)
+
+    annotation["text"] = lr_strip
+    annotation["start"] -= l_pad
+    annotation["end"] -= l_pad + r_pad
+
+    return annotation

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -405,14 +405,14 @@ class TestSequenceLabeler(unittest.TestCase):
 
     def test_labeled_whitespace(self):
         model = SequenceLabeler()
-        text = "I am a dog. A dog that's incredibly bright. I can talk, read, and write!"
-        labels = [{"start": 0, "end": 7, "text": "I am a ", "label": "entity"}]
+        text = " I am a dog. A dog that's incredibly bright. I can talk, read, and write!"
+        labels = [{"start": 0, "end": 8, "text": " I am a ", "label": "entity"}]
         model.fit([text] * 30, [labels] * 30)
         preds = model.predict([text])[0]
         self.assertEqual(len(preds), 1)
         for p in preds:
             del p["confidence"]
-        correct_label = [{"start": 0, "end": 6, "text": "I am a", "label": "entity"}]
+        correct_label = [{"start": 1, "end": 7, "text": "I am a", "label": "entity"}]
         self.assertEqual(preds, correct_label)
 
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -403,6 +403,18 @@ class TestSequenceLabeler(unittest.TestCase):
         num_dog_pre_chunk_preds = len([p for p in pre_chunk_preds[0] if p["text"] == "dog"])
         assert num_dog_pre_chunk_preds / num_dog_preds >= 0.95
 
+    def test_labeled_whitespace(self):
+        model = SequenceLabeler()
+        text = "I am a dog. A dog that's incredibly bright. I can talk, read, and write!"
+        labels = [{"start": 0, "end": 7, "text": "I am a ", "label": "entity"}]
+        model.fit([text] * 30, [labels] * 30)
+        preds = model.predict([text])[0]
+        self.assertEqual(len(preds), 1)
+        for p in preds:
+            del p["confidence"]
+        correct_label = [{"start": 0, "end": 6, "text": "I am a", "label": "entity"}]
+        self.assertEqual(preds, correct_label)
+
 
 class TestSequenceMemoryLeak(unittest.TestCase):
 


### PR DESCRIPTION
Add additional post-processing to `finetune_to_indico_sequence()` that strips whitespace from the start and end of predictions.