### PR TITLE
FIX: pin numpy to <1.24 for use of deprecated types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools.command.build_ext import build_ext
 REQUIREMENTS = [
     "pandas>=0.23.1",
     "tqdm>=4.0.0",
-    "numpy>=1.18.4",
+    "numpy>=1.18.4,<1.24.0",
     "scipy>=1.1.0",
     "scikit-learn>=1.0.2",
     "ftfy>=4.4.0",


### PR DESCRIPTION
1.24 removes np.float, etc - if we wanna be compat with numpy 1.18, we need to keep using these types so pinning to <1.24