### PR TITLE
ADD: [DEV-14285] use XLA for table model

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+        name: isort (python)
+        args: ["--profile", "black"]
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black
+        language_version: python3.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 
 RUN pip3 install tensorflow[and-cuda]==2.20.0
-RUN apt update && apt install -y cmake g++ 
+RUN apt update && apt install -y cmake g++
 
 # tensorboard
 EXPOSE 6006

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-RUN pip3 install tensorflow[and-cuda]==2.19.0
+RUN pip3 install tensorflow[and-cuda]==2.20.0
 RUN apt update && apt install -y cmake g++ 
 
 # tensorboard

--- a/finetune/base.py
+++ b/finetune/base.py
@@ -288,7 +288,8 @@ class BaseModel(object, metaclass=ABCMeta):
             # verbose=2 results in one line logged per epoch. These are not always intuitive
             # because their epoch numbers don't align with ours when we're using ANS.
             # However, for now it's nice to get signs of life from keras.
-            verbose=2,
+            # We have to disable it when there will only be a single step due to a bug in keras ProgBar
+            verbose=2 if steps_per_epoch * self.config.n_epochs > 1 else 0,
         )
         # tf.profiler.experimental.stop()
         self._trained = True

--- a/finetune/base.py
+++ b/finetune/base.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Mapping, Tuple
 import joblib
 import numpy as np
 import tensorflow as tf
+from tensorflow.python.framework.ops import gradient_registry as tf_gradient_registry
 from tensorflow.python.keras.backend import reset_uids as keras_reset_uids
 
 from finetune.base_models.bert.roberta_encoder import RoBERTaEncoderV2
@@ -88,6 +89,12 @@ class FinetuneRegistry:
         """
         Close all live models and clear dead weakrefs, then clear the Keras session.
         """
+        # There are other registries in the tensorflow.python.framework.ops that we can clear if we need to.
+        tf_gradient_registry._registry = {
+            k: v
+            for k, v in tf_gradient_registry._registry.items()
+            if not k.startswith("CustomGradient")
+        }
         with self._refs_lock:
             for model in self.live_models():
                 model.close()
@@ -721,3 +728,7 @@ class BaseModel(object, metaclass=ABCMeta):
             self.saver.update_variables(self._model)
         del self._model
         self._model = None
+        self.input_pipeline._batch_postprocessor = (
+            self.input_pipeline.MISSING_BATCH_POSTPROCESSOR
+        )
+        self.input_pipeline._text_encoder = None

--- a/finetune/base_models/__init__.py
+++ b/finetune/base_models/__init__.py
@@ -23,6 +23,10 @@ class SourceModel(metaclass=ABCMeta):
         settings.update(cls.settings)
         return settings
 
+    @classmethod
+    def get_batch_postprocessor(cls, config):
+        return None
+
     @property
     @abstractmethod
     def encoder(cls):

--- a/finetune/base_models/bert/model.py
+++ b/finetune/base_models/bert/model.py
@@ -1,5 +1,4 @@
 import os
-import functools
 from urllib.parse import urljoin
 
 from finetune.base_models import SourceModel
@@ -16,12 +15,12 @@ from finetune.base_models.bert.modeling import (
     TwinBertFeaturizer,
     XDocModel,
 )
-from finetune.base_models.bert.table_utils import TableModelBatchPostprocessor
 from finetune.base_models.bert.roberta_encoder import (
     RoBERTaEncoder,
     RoBERTaEncoderV2,
     RoBERTaEncoderXDoc,
 )
+from finetune.base_models.bert.table_utils import TableModelBatchPostprocessor
 from finetune.util.context_utils import get_context_doc_rep, get_context_layoutlm
 from finetune.util.download import (
     BERT_BASE_URL,
@@ -515,7 +514,7 @@ class TableRoBERTa(_BaseBert):
         "include_bos_eos": False,
         "permit_uninitialized": r"mixing_fn_|pos_|kernel|bias",  # TODO: this can be refined.
         "predict_batch_size": 1,
-        "extra_data_epochs": 1, # Just a fudge for now because we draw down one epoch for batch stats.
+        "extra_data_epochs": 1,  # Just a fudge for now because we draw down one epoch for batch stats.
     }
     required_files = [
         {

--- a/finetune/base_models/bert/model.py
+++ b/finetune/base_models/bert/model.py
@@ -1,4 +1,5 @@
 import os
+import functools
 from urllib.parse import urljoin
 
 from finetune.base_models import SourceModel
@@ -14,6 +15,7 @@ from finetune.base_models.bert.modeling import (
     LayoutLMModel,
     TwinBertFeaturizer,
     XDocModel,
+    TableModelBatchPostprocessor,
 )
 from finetune.base_models.bert.roberta_encoder import (
     RoBERTaEncoder,
@@ -484,7 +486,7 @@ class TableRoBERTa(_BaseBert):
     # Due to use of ragged tensors we cannot support XLA for this model.
     # Wrapping the inner call method in a tf.function with jit_compile=False causes missing gradient errors that I don't understand.
     # Longeer term we should try to refactor this to use a more XLA friendly approach.
-    supports_xla = False
+    supports_xla = True
     settings = {
         **BERT_BASE_PARAMS,
         # Just incase all cells fall into the same buckets this -8 allows us to pack the batches much tighter once we add EOS and BOS
@@ -538,3 +540,7 @@ class TableRoBERTa(_BaseBert):
             "url": urljoin(ROBERTA_BASE_URL, "roberta_encoder.json"),
         },
     ]
+
+    @classmethod
+    def get_batch_postprocessor(cls, config):
+        return TableModelBatchPostprocessor(config=config)

--- a/finetune/base_models/bert/model.py
+++ b/finetune/base_models/bert/model.py
@@ -15,8 +15,8 @@ from finetune.base_models.bert.modeling import (
     LayoutLMModel,
     TwinBertFeaturizer,
     XDocModel,
-    TableModelBatchPostprocessor,
 )
+from finetune.base_models.bert.table_utils import TableModelBatchPostprocessor
 from finetune.base_models.bert.roberta_encoder import (
     RoBERTaEncoder,
     RoBERTaEncoderV2,
@@ -515,6 +515,7 @@ class TableRoBERTa(_BaseBert):
         "include_bos_eos": False,
         "permit_uninitialized": r"mixing_fn_|pos_|kernel|bias",  # TODO: this can be refined.
         "predict_batch_size": 1,
+        "extra_data_epochs": 1, # Just a fudge for now because we draw down one epoch for batch stats.
     }
     required_files = [
         {

--- a/finetune/base_models/bert/model.py
+++ b/finetune/base_models/bert/model.py
@@ -491,9 +491,9 @@ class TableRoBERTa(_BaseBert):
         **BERT_BASE_PARAMS,
         # Just incase all cells fall into the same buckets this -8 allows us to pack the batches much tighter once we add EOS and BOS
         "max_length": 2048 - 8,
-        "table_batching": True,
+        "table_batching": False,
         "chunk_tables": True,
-        "batch_size": 2,  # When table batching is true this becomes a nominal batch size. Very long docs have batch size = 1
+        "batch_size": 1,  # When table batching is true this becomes a nominal batch size. Very long docs have batch size = 1
         "class_weights": None,
         "n_epochs": 24,
         "epsilon": 1e-8,

--- a/finetune/base_models/bert/modeling.py
+++ b/finetune/base_models/bert/modeling.py
@@ -29,6 +29,7 @@ from finetune.base_models.bert.table_utils import (
     get_row_col_values,
     reassemble_sequence_feats,
     scatter_feats,
+    get_target_length,
 )
 from finetune.nn.activations import bert_gelu as gelu
 from finetune.nn.activations import hf_gelu
@@ -70,7 +71,7 @@ class Embedding(tf.keras.layers.Layer):
             token_type_ids=token_type_ids,
             position_ids=position_ids,
         )
-        post_processed.set_shape(embedding_output.shape)
+        post_processed = tf.ensure_shape(post_processed, embedding_output.shape)
         return post_processed
 
 
@@ -391,7 +392,7 @@ class LayerNorm(tf.keras.layers.Layer):
             scale=self.gamma,
             variance_epsilon=variance_epsilon,
         )
-        outputs.set_shape(inputs_shape)
+        outputs = tf.ensure_shape(outputs, inputs_shape)
         return outputs
 
 
@@ -981,8 +982,7 @@ class TransformerModel(tf.keras.layers.Layer):
             )
             if self.recompute_grad and training:
                 block = tf.recompute_grad(block)
-            prev_output = block(prev_output)
-            prev_output.set_shape(block_shape)
+            prev_output = tf.ensure_shape(block(prev_output), block_shape)
         final_output = reshape_from_matrix(prev_output, input_shape)
         return final_output
 
@@ -1469,11 +1469,12 @@ class TableModelBatchPostprocessor:
 
     def modify_input_spec(self, input_spec):
         (types, target_type), (shapes, target_shape) = input_spec
+        table_seq_length = get_target_length()
         gather_shapes = {
             "seq_lens": tf.TensorShape([None]),
-            "values": tf.TensorShape([None, None, 2]),
-            "attn_mask": tf.TensorShape([None, None, None]),
-            "pos_ids": tf.TensorShape([None, None]),
+            "values": tf.TensorShape([None, table_seq_length, 2]),
+            "attn_mask": tf.TensorShape([None, table_seq_length, table_seq_length]),
+            "pos_ids": tf.TensorShape([None, table_seq_length]),
         }
         gather_types = {
             "seq_lens": tf.int32,
@@ -1488,30 +1489,31 @@ class TableModelBatchPostprocessor:
         return (types, target_type), (shapes, target_shape)
 
     def postprocess(self, x, y=None):
-        # Extract row/column boundaries from context
-        end_col, end_row, start_col, start_row = tf.unstack(tf.cast(x["context"], tf.int32), num=4, axis=2)
+        # Should run on cpu anyway but just to be safe.
+        with tf.device("/CPU:0"):
+            end_col, end_row, start_col, start_row = tf.unstack(tf.cast(x["context"], tf.int32), num=4, axis=2)
 
-        # Get gather indices for rows and columns
-        row_gather = get_gather_indices(
-            x["tokens"],
-            x["length"],
-            start_row,
-            end_row,
-            other_end=end_col,
-            chunk_tables=self.config.chunk_tables,
-        )
-        col_gather = get_gather_indices(
-            x["tokens"],
-            x["length"],
-            start_col,
-            end_col,
-            other_end=end_row,
-            chunk_tables=self.config.chunk_tables,
-        )
-        x = {**x, "row_gather": row_gather, "col_gather": col_gather}
-        if y is not None:
-            return x, y
-        return x
+            # Get gather indices for rows and columns
+            row_gather = get_gather_indices(
+                x["tokens"],
+                x["length"],
+                start_row,
+                end_row,
+                other_end=end_col,
+                chunk_tables=self.config.chunk_tables,
+            )
+            col_gather = get_gather_indices(
+                x["tokens"],
+                x["length"],
+                start_col,
+                end_col,
+                other_end=end_row,
+                chunk_tables=self.config.chunk_tables,
+            )
+            x = {**x, "row_gather": row_gather, "col_gather": col_gather}
+            if y is not None:
+                return x, y
+            return x
 
 class TwinBertFeaturizer(tf.keras.layers.Layer):
     """Keras layer wrapper for the twin BERT featurizer functionality."""
@@ -1529,6 +1531,7 @@ class TwinBertFeaturizer(tf.keras.layers.Layer):
     def build(self, input_shape):
         # Just needed to keep keras logs quiet as no variables are directly built on this layer
         super().build(input_shape)
+
 
     def call(self, tokens, context, sequence_lengths, row_gather, col_gather):
         """

--- a/finetune/base_models/bert/modeling.py
+++ b/finetune/base_models/bert/modeling.py
@@ -1002,9 +1002,8 @@ def get_shape_list(tensor, expected_rank=None, name=None):
             be returned as python integers, and dynamic dimensions will be returned
             as tf.Tensor scalars.
     """
-
     shape = tensor.shape.as_list()
-
+    
     non_static_indexes = []
     for index, dim in enumerate(shape):
         if dim is None:
@@ -1193,7 +1192,6 @@ class TwinTransformerModel(tf.keras.layers.Layer):
                 name=f"layer_a_{i}",
             )
             self.blocks_a.append(block_a)
-
             block_b = FullBlock(
                 attention_head_size=attention_head_size_b,
                 num_attention_heads=self.num_attention_heads,
@@ -1398,7 +1396,6 @@ class BaseTwinBertModel(tf.keras.layers.Layer):
             token_type_ids=token_type_ids_b,
             position_ids=pos_ids_b,
         )
-
         # Run the twin transformer
         sequence_output_a, sequence_output_b = self.transformer_model(
             layer_input_a=embedding_output_a,
@@ -1466,7 +1463,55 @@ class TwinBertModel(tf.keras.layers.Layer):
             mixing_inputs=mixing_inputs,
             **kwargs,
         )
+class TableModelBatchPostprocessor:
+    def __init__(self, config=None):
+        self.config = config
 
+    def modify_input_spec(self, input_spec):
+        (types, target_type), (shapes, target_shape) = input_spec
+        gather_shapes = {
+            "seq_lens": tf.TensorShape([None]),
+            "values": tf.TensorShape([None, None, 2]),
+            "attn_mask": tf.TensorShape([None, None, None]),
+            "pos_ids": tf.TensorShape([None, None]),
+        }
+        gather_types = {
+            "seq_lens": tf.int32,
+            "values": tf.int32,
+            "attn_mask": tf.float32,
+            "pos_ids": tf.int32,
+        }
+        shapes["row_gather"] = gather_shapes
+        shapes["col_gather"] = gather_shapes
+        types["row_gather"] = gather_types
+        types["col_gather"] = gather_types
+        return (types, target_type), (shapes, target_shape)
+
+    def postprocess(self, x, y=None):
+        # Extract row/column boundaries from context
+        end_col, end_row, start_col, start_row = tf.unstack(tf.cast(x["context"], tf.int32), num=4, axis=2)
+
+        # Get gather indices for rows and columns
+        row_gather = get_gather_indices(
+            x["tokens"],
+            x["length"],
+            start_row,
+            end_row,
+            other_end=end_col,
+            chunk_tables=self.config.chunk_tables,
+        )
+        col_gather = get_gather_indices(
+            x["tokens"],
+            x["length"],
+            start_col,
+            end_col,
+            other_end=end_row,
+            chunk_tables=self.config.chunk_tables,
+        )
+        x = {**x, "row_gather": row_gather, "col_gather": col_gather}
+        if y is not None:
+            return x, y
+        return x
 
 class TwinBertFeaturizer(tf.keras.layers.Layer):
     """Keras layer wrapper for the twin BERT featurizer functionality."""
@@ -1485,7 +1530,7 @@ class TwinBertFeaturizer(tf.keras.layers.Layer):
         # Just needed to keep keras logs quiet as no variables are directly built on this layer
         super().build(input_shape)
 
-    def call(self, tokens, context, sequence_lengths):
+    def call(self, tokens, context, sequence_lengths, row_gather, col_gather):
         """
         Main featurizer call that processes the input tokens and context.
 
@@ -1497,29 +1542,10 @@ class TwinBertFeaturizer(tf.keras.layers.Layer):
         Returns:
             Dictionary containing features and sequence features
         """
+        tokens = tf.ensure_shape(tokens, [None, None])
+        context = tf.ensure_shape(context, [None, None, 4])
         batch_size = tf.shape(tokens)[0]
         seq_length = tf.shape(tokens)[1]
-
-        # Extract row/column boundaries from context
-        end_col, end_row, start_col, start_row = tf.unstack(context, num=4, axis=2)
-
-        # Get gather indices for rows and columns
-        row_gather = get_gather_indices(
-            tokens,
-            sequence_lengths,
-            start_row,
-            end_row,
-            other_end=end_col,
-            chunk_tables=self.chunk_tables,
-        )
-        col_gather = get_gather_indices(
-            tokens,
-            sequence_lengths,
-            start_col,
-            end_col,
-            other_end=end_row,
-            chunk_tables=self.chunk_tables,
-        )
 
         # Get row/column values for processing
         row_col_values = get_row_col_values(
@@ -1527,8 +1553,8 @@ class TwinBertFeaturizer(tf.keras.layers.Layer):
             context,
             row_gather,
             col_gather,
-            bos_id=self.encoder.start_token,
-            eos_id=self.encoder.end_token,
+            bos_id=tf.ensure_shape(self.encoder.start_token, []),
+            eos_id=tf.ensure_shape(self.encoder.end_token, []),
             table_position_type=self.table_position_type,
             max_row_col_embedding=512,  # Default value
         )
@@ -1655,7 +1681,7 @@ class TableCrossRowColMixing(tf.keras.layers.Layer):
             row_gather,
             bos_pad=self.bos_var,
             eos_pad=self.eos_var,
-            pad_val=1234,
+            pad_val=tf.convert_to_tensor(1234, dtype=self.bos_var.dtype),
         )["values"]
 
         # Scatter row feats into cols arrangement.
@@ -1664,7 +1690,7 @@ class TableCrossRowColMixing(tf.keras.layers.Layer):
             col_gather,
             bos_pad=self.bos_var,
             eos_pad=self.eos_var,
-            pad_val=1234,
+            pad_val=tf.convert_to_tensor(1234, dtype=self.bos_var.dtype),
         )["values"]
 
         return (

--- a/finetune/base_models/bert/modeling.py
+++ b/finetune/base_models/bert/modeling.py
@@ -1001,7 +1001,7 @@ def get_shape_list(tensor, expected_rank=None, name=None):
             as tf.Tensor scalars.
     """
     shape = tensor.shape.as_list()
-    
+
     non_static_indexes = []
     for index, dim in enumerate(shape):
         if dim is None:
@@ -1479,7 +1479,6 @@ class TwinBertFeaturizer(tf.keras.layers.Layer):
     def build(self, input_shape):
         # Just needed to keep keras logs quiet as no variables are directly built on this layer
         super().build(input_shape)
-
 
     def call(self, tokens, context, sequence_lengths, row_gather, col_gather):
         """

--- a/finetune/base_models/bert/modeling.py
+++ b/finetune/base_models/bert/modeling.py
@@ -25,11 +25,9 @@ import tensorflow as tf
 from finetune.base_models.bert.roberta_encoder import RoBERTaEncoder
 from finetune.base_models.bert.table_utils import (
     gather_col_vals,
-    get_gather_indices,
     get_row_col_values,
     reassemble_sequence_feats,
     scatter_feats,
-    get_target_length,
 )
 from finetune.nn.activations import bert_gelu as gelu
 from finetune.nn.activations import hf_gelu
@@ -1463,57 +1461,7 @@ class TwinBertModel(tf.keras.layers.Layer):
             mixing_inputs=mixing_inputs,
             **kwargs,
         )
-class TableModelBatchPostprocessor:
-    def __init__(self, config=None):
-        self.config = config
 
-    def modify_input_spec(self, input_spec):
-        (types, target_type), (shapes, target_shape) = input_spec
-        table_seq_length = get_target_length()
-        gather_shapes = {
-            "seq_lens": tf.TensorShape([None]),
-            "values": tf.TensorShape([None, table_seq_length, 2]),
-            "attn_mask": tf.TensorShape([None, table_seq_length, table_seq_length]),
-            "pos_ids": tf.TensorShape([None, table_seq_length]),
-        }
-        gather_types = {
-            "seq_lens": tf.int32,
-            "values": tf.int32,
-            "attn_mask": tf.float32,
-            "pos_ids": tf.int32,
-        }
-        shapes["row_gather"] = gather_shapes
-        shapes["col_gather"] = gather_shapes
-        types["row_gather"] = gather_types
-        types["col_gather"] = gather_types
-        return (types, target_type), (shapes, target_shape)
-
-    def postprocess(self, x, y=None):
-        # Should run on cpu anyway but just to be safe.
-        with tf.device("/CPU:0"):
-            end_col, end_row, start_col, start_row = tf.unstack(tf.cast(x["context"], tf.int32), num=4, axis=2)
-
-            # Get gather indices for rows and columns
-            row_gather = get_gather_indices(
-                x["tokens"],
-                x["length"],
-                start_row,
-                end_row,
-                other_end=end_col,
-                chunk_tables=self.config.chunk_tables,
-            )
-            col_gather = get_gather_indices(
-                x["tokens"],
-                x["length"],
-                start_col,
-                end_col,
-                other_end=end_row,
-                chunk_tables=self.config.chunk_tables,
-            )
-            x = {**x, "row_gather": row_gather, "col_gather": col_gather}
-            if y is not None:
-                return x, y
-            return x
 
 class TwinBertFeaturizer(tf.keras.layers.Layer):
     """Keras layer wrapper for the twin BERT featurizer functionality."""
@@ -1601,7 +1549,7 @@ class TwinBertFeaturizer(tf.keras.layers.Layer):
 
         # Return the expected format
         return {
-            # "features": tf.zeros(shape=[batch_size, 768]),
+            "features": tf.zeros(shape=[batch_size, 768]),
             "sequence_features": sequence_features,
         }
 
@@ -1699,17 +1647,4 @@ class TableCrossRowColMixing(tf.keras.layers.Layer):
         return (
             self.adaptor_col(col_feats_reshaped) + row_feats,
             self.adaptor_row(row_feats_reshaped) + col_feats,
-        )
-
-    def _scatter_feats(self, output_shape, sequence_feats, scatter_vals):
-        """Scatter features back to original shape."""
-        input_tensor = tf.zeros(shape=output_shape, dtype=tf.float32)
-        mask = tf.math.less(scatter_vals[:, :, 1], output_shape[1])
-        feats = tf.boolean_mask(sequence_feats, mask)
-        scatter_idxs = tf.boolean_mask(scatter_vals, mask)
-        divide_by = tf.tensor_scatter_nd_add(
-            input_tensor, scatter_idxs, tf.ones_like(feats)
-        )
-        return tf.math.divide_no_nan(
-            tf.tensor_scatter_nd_add(input_tensor, scatter_idxs, feats), divide_by
         )

--- a/finetune/base_models/bert/table_utils.py
+++ b/finetune/base_models/bert/table_utils.py
@@ -313,10 +313,10 @@ def slice_by_table_indices(
 
     col_values.set_shape([None, None] + list(inp.shape[2:]))
     return {
-        "seq_lens": col_seq_lens,
+        "seq_lens": tf.cast(col_seq_lens, tf.int32),
         "values": col_values,
         "attn_mask": mask,
-        "pos_ids": pos_ids,
+        "pos_ids": tf.cast(pos_ids, tf.int32),
     }
 
 
@@ -338,19 +338,27 @@ def gather_col_vals(inp, gather_output, eos_pad, bos_pad, pad_val):
             "attn_mask": mask from gather output unmodified,
         }
     """
-    bs = tf.shape(inp)[0]
-    bos_expanded = tf.tile(
-        tf.expand_dims(tf.expand_dims(bos_pad, 0), 0),
-        [bs, 1, *(1 for _ in bos_pad.shape)],
-    )
-    eos_expanded = tf.tile(
-        tf.expand_dims(tf.expand_dims(eos_pad, 0), 0),
-        [bs, 1, *(1 for _ in eos_pad.shape)],
-    )
+    # bs = tf.shape(inp)[0]
+    # bos_expanded = tf.tile(
+    #     tf.expand_dims(tf.expand_dims(bos_pad, 0), 0),
+    #     [bs, 1, *(1 for _ in bos_pad.shape)],
+    # )
+    # eos_expanded = tf.tile(
+    #     tf.expand_dims(tf.expand_dims(eos_pad, 0), 0),
+    #     [bs, 1, *(1 for _ in eos_pad.shape)],
+    # )
+    hidden_dim = inp.shape[2:]
+    batch_size = tf.shape(inp)[0]
+    token_bcast_shape = [batch_size, 1, *hidden_dim]
+    bos_expanded = tf.broadcast_to(bos_pad, token_bcast_shape)
+    eos_expanded = tf.broadcast_to(eos_pad, token_bcast_shape)
+    pad_expanded = tf.broadcast_to(pad_val, token_bcast_shape)
     inp_w_extra_toks = tf.concat(
-        [inp, bos_expanded, eos_expanded, tf.ones_like(eos_expanded) * pad_val], axis=1
+        [inp, bos_expanded, eos_expanded, pad_expanded], axis=1
     )
     values = tf.gather_nd(indices=gather_output["values"], params=inp_w_extra_toks)
+    # output always has the same rank as the input.
+    values = tf.ensure_shape(values, [None for _ in inp.shape])
     return {
         "seq_lens": gather_output["seq_lens"],
         "values": values,
@@ -411,8 +419,8 @@ def get_row_col_values(
             X,
             row_gather,
             context,
-            bos_id=tf.constant(bos_id),
-            eos_id=tf.constant(eos_id),
+            bos_id=tf.convert_to_tensor(bos_id),
+            eos_id=tf.convert_to_tensor(eos_id),
             table_position_type=table_position_type,
             max_row_col_embedding=max_row_col_embedding,
         ),
@@ -420,8 +428,8 @@ def get_row_col_values(
             X,
             col_gather,
             context,
-            bos_id=tf.constant(bos_id),
-            eos_id=tf.constant(eos_id),
+            bos_id=tf.convert_to_tensor(bos_id),
+            eos_id=tf.convert_to_tensor(eos_id),
             table_position_type=table_position_type,
             max_row_col_embedding=max_row_col_embedding,
         ),

--- a/finetune/base_models/bert/table_utils.py
+++ b/finetune/base_models/bert/table_utils.py
@@ -1,6 +1,8 @@
-import tensorflow as tf
-from finetune.nn.activations import bert_gelu as gelu
 import logging
+
+import tensorflow as tf
+
+from finetune.nn.activations import bert_gelu as gelu
 
 LOGGER = logging.getLogger("finetune")
 
@@ -188,7 +190,9 @@ def compute_masked_ragged_indices(
         start_e = tf.expand_dims(start, 0)  # 1, batch, max_len
         end_e = tf.expand_dims(end, 0)  # 1, batch, max_len
         col_masks = tf.math.logical_and(
-            tf.math.logical_and(tf.math.less_equal(start_e, range_), tf.math.less_equal(range_, end_e)),
+            tf.math.logical_and(
+                tf.math.less_equal(start_e, range_), tf.math.less_equal(range_, end_e)
+            ),
             mask,
         )  # num_cols, batch, seq
 
@@ -197,7 +201,7 @@ def compute_masked_ragged_indices(
         scatter_idx_orig = tf.stack([batch_idx, seq_idx], axis=-1)  # batch, seq, 2
 
         inp_expanded = tf.expand_dims(scatter_idx_orig, 0)  # 1, bs, seq, 2
-        
+
         inp_values_i = tf.ragged.boolean_mask(
             tf.tile(inp_expanded, [tf.shape(col_masks)[0], 1, 1, 1]), col_masks
         ).merge_dims(0, 1)
@@ -209,9 +213,11 @@ def compute_masked_ragged_indices(
         )
         if chunk_tables:
             inp_values = chunk_ragged_tensor(
-                inp_values, other_end=other_end, base_model_max_length=base_model_max_length - 2
+                inp_values,
+                other_end=other_end,
+                base_model_max_length=base_model_max_length - 2,
             )  # -2 for EOS and BOS
-                # Prepare BOS/EOS paddings
+            # Prepare BOS/EOS paddings
         bos_pad = tf.convert_to_tensor([0, seq_len + 1])
         eos_pad = tf.convert_to_tensor([0, seq_len])
 
@@ -246,7 +252,13 @@ def build_gather_outputs(
 ):
     with tf.device("cpu"):
         output_ragged = compute_masked_ragged_indices(
-            X, sequence_lengths, start, end, other_end, chunk_tables, base_model_max_length
+            X,
+            sequence_lengths,
+            start,
+            end,
+            other_end,
+            chunk_tables,
+            base_model_max_length,
         )
         pad_val = tf.convert_to_tensor([0, tf.shape(X)[1] + 2])
         output_ragged, mask, pos_ids = batch_packing(
@@ -304,17 +316,27 @@ def build_gather_outputs(
         seq_padding = tf.maximum(target_seq_len - tf.shape(col_values)[1], 0)
         batch_padding = tf.maximum(target_batch_size - tf.shape(col_values)[0], 0)
         pad0 = tf.pad(
-            col_values[:, :target_seq_len, 0], [[0, batch_padding], [0, seq_padding]], constant_values=pad_val[0]
+            col_values[:, :target_seq_len, 0],
+            [[0, batch_padding], [0, seq_padding]],
+            constant_values=pad_val[0],
         )
         pad1 = tf.pad(
-            col_values[:, :target_seq_len, 1], [[0, batch_padding], [0, seq_padding]], constant_values=pad_val[1]
+            col_values[:, :target_seq_len, 1],
+            [[0, batch_padding], [0, seq_padding]],
+            constant_values=pad_val[1],
         )
         col_values = tf.stack([pad0, pad1], axis=-1)
         if include_mask:
             mask = tf.pad(
-                mask[:, :target_seq_len, :target_seq_len], [[0, batch_padding], [0, seq_padding], [0, seq_padding]], constant_values=0
+                mask[:, :target_seq_len, :target_seq_len],
+                [[0, batch_padding], [0, seq_padding], [0, seq_padding]],
+                constant_values=0,
             )
-        pos_ids = tf.pad(pos_ids[:, :target_seq_len], [[0, batch_padding], [0, seq_padding]], constant_values=0)
+        pos_ids = tf.pad(
+            pos_ids[:, :target_seq_len],
+            [[0, batch_padding], [0, seq_padding]],
+            constant_values=0,
+        )
 
     col_values.set_shape([None, None, 2])
     return {
@@ -462,7 +484,6 @@ def scatter_feats(output_shape, sequence_feats, scatter_vals):
     return tf.math.divide_no_nan(
         tf.tensor_scatter_nd_add(input_tensor, scatter_idxs, feats), divide_by
     )  # [text_batch, text_seq, feat_dim]
-   
 
 
 def get_summary_values(inp, gather_vals, input_seq_len):
@@ -520,6 +541,7 @@ def reassemble_sequence_feats(
 
     return feats
 
+
 class TableModelBatchPostprocessor:
     def __init__(self, config=None):
         self.config = config
@@ -545,7 +567,16 @@ class TableModelBatchPostprocessor:
         types["col_gather"] = gather_types
         return (types, target_type), (shapes, target_shape)
 
-    def _postprocess(self, x, y=None, target_row_len=None, target_col_len=None, target_row_batch_size=None, target_col_batch_size=None, training=True):
+    def _postprocess(
+        self,
+        x,
+        y=None,
+        target_row_len=None,
+        target_col_len=None,
+        target_row_batch_size=None,
+        target_col_batch_size=None,
+        training=True,
+    ):
         # Should run on cpu anyway but just to be safe.
         with tf.device("/CPU:0"):
             end_col, end_row, start_col, start_row = tf.unstack(
@@ -593,7 +624,10 @@ class TableModelBatchPostprocessor:
             if mode == "train":
                 # If we already computed stats for this postprocessor, just reuse them
                 if self._cached_stats is None:
-                    LOGGER.info("Running down 1 epoch of the dataset to calculate optimal batch size and sequence length for table model.")
+                    LOGGER.info(
+                        "Running down 1 epoch of the dataset to calculate optimal batch size and sequence length for table model."
+                    )
+
                     def _stats_map(*args):
                         if len(args) == 2:
                             x, _y = args
@@ -620,8 +654,10 @@ class TableModelBatchPostprocessor:
                         )
                         return ragged_rows, ragged_cols
 
-                    ragged_values = (
-                        ds.map(_stats_map, num_parallel_calls=tf.data.AUTOTUNE, deterministic=False)
+                    ragged_values = ds.map(
+                        _stats_map,
+                        num_parallel_calls=tf.data.AUTOTUNE,
+                        deterministic=False,
                     )
 
                     # Compute maxima across the bounded window
@@ -629,10 +665,12 @@ class TableModelBatchPostprocessor:
                     max_col_seq_len = 0
                     for ragged_rows, ragged_cols in ragged_values:
                         max_row_seq_len = max(
-                            max_row_seq_len, int(tf.reduce_max(ragged_rows.row_lengths()).numpy())
+                            max_row_seq_len,
+                            int(tf.reduce_max(ragged_rows.row_lengths()).numpy()),
                         )
                         max_col_seq_len = max(
-                            max_col_seq_len, int(tf.reduce_max(ragged_cols.row_lengths()).numpy())
+                            max_col_seq_len,
+                            int(tf.reduce_max(ragged_cols.row_lengths()).numpy()),
                         )
 
                     # Compute packed batch sizes using those maxima
@@ -665,14 +703,25 @@ class TableModelBatchPostprocessor:
                         int(row_batch_size),
                         int(col_batch_size),
                     )
-                    LOGGER.info(f"Completed calculating stats. Cached stats: {self._cached_stats}")
+                    LOGGER.info(
+                        f"Completed calculating stats. Cached stats: {self._cached_stats}"
+                    )
                 else:
                     LOGGER.info("Reusing cached stats")
 
                 # Unpack cached stats
-                max_row_seq_len, max_col_seq_len, row_batch_size, col_batch_size = self._cached_stats
-                target_col_batch_size = tf.convert_to_tensor(col_batch_size, dtype=tf.int32)
-                target_row_batch_size = tf.convert_to_tensor(row_batch_size, dtype=tf.int32)
+                (
+                    max_row_seq_len,
+                    max_col_seq_len,
+                    row_batch_size,
+                    col_batch_size,
+                ) = self._cached_stats
+                target_col_batch_size = tf.convert_to_tensor(
+                    col_batch_size, dtype=tf.int32
+                )
+                target_row_batch_size = tf.convert_to_tensor(
+                    row_batch_size, dtype=tf.int32
+                )
                 target_col_len = tf.convert_to_tensor(max_col_seq_len, dtype=tf.int32)
                 target_row_len = tf.convert_to_tensor(max_row_seq_len, dtype=tf.int32)
 
@@ -689,7 +738,7 @@ class TableModelBatchPostprocessor:
                         target_col_len=target_col_len,
                         target_row_batch_size=target_row_batch_size,
                         target_col_batch_size=target_col_batch_size,
-                        training=True
+                        training=True,
                     )
 
                 return ds.map(_train_map, num_parallel_calls=tf.data.AUTOTUNE)

--- a/finetune/base_models/bert/table_utils.py
+++ b/finetune/base_models/bert/table_utils.py
@@ -563,7 +563,6 @@ class TableModelBatchPostprocessor:
                 training=training,
                 target_seq_len=target_row_len,
                 target_batch_size=target_row_batch_size,
-                base_model_max_length=self.config.max_length,
             )
             col_gather = build_gather_outputs(
                 X=x["tokens"],
@@ -576,7 +575,6 @@ class TableModelBatchPostprocessor:
                 training=training,
                 target_seq_len=target_col_len,
                 target_batch_size=target_col_batch_size,
-                base_model_max_length=self.config.max_length,
             )
             x = {**x, "row_gather": row_gather, "col_gather": col_gather}
             if y is not None:
@@ -611,7 +609,6 @@ class TableModelBatchPostprocessor:
                             end_row,
                             other_end=end_col,
                             chunk_tables=self.config.chunk_tables,
-                            base_model_max_length=self.config.max_length,
                         )
                         ragged_cols = compute_masked_ragged_indices(
                             x["tokens"],
@@ -620,7 +617,6 @@ class TableModelBatchPostprocessor:
                             end_col,
                             other_end=end_row,
                             chunk_tables=self.config.chunk_tables,
-                            base_model_max_length=self.config.max_length,
                         )
                         return ragged_rows, ragged_cols
 

--- a/finetune/base_models/bert/table_utils.py
+++ b/finetune/base_models/bert/table_utils.py
@@ -1,72 +1,17 @@
 import tensorflow as tf
 from finetune.nn.activations import bert_gelu as gelu
+import logging
+
+LOGGER = logging.getLogger("finetune")
 
 
-def get_gather_indices(X, sequence_lengths, start, end, other_end, chunk_tables):
-    """
-    Given the tokens, sequence lengths and the range of each token in either rows or columns
-    gets the values required for gathering the input tokens into row/column stack inputs and
-    scattering the features back into it's original shape.
-
-    It also returns the masks to be used by the attention operations and a new set of
-    sequence lengths.
-
-    Internally - Special tokens are appended to X before the gathers are applied.
-
-    Additionally, long rows / columns are chunked up, retaining 2 columns / rows of context (intended to be the headers) into every chunk.
-
-    Args:
-        X: Input tokens [batch, sequence]
-        sequence_lengths: Number of tokens per sequence [batch]
-        start: The start of the col/row range.
-        end: The end of the col/row range.
-        other_end: The end of the row/col range. This is used to determine the first 2 rows / cols to retain in all chunks for context.
-        chunk_tables: a boolean. Whether to apply the chunking operation described above
-
-    Returns:
-    A dict:
-    {
-        "seq_lens": New sequence lengths [new_batch],
-        "values": Indexes into the original sequence of the new batches of data. [new_batch, new_seq_len],
-        "attn_mask": Mask for the new sequences [new_batch, new_seq_len, new_seq_len],
-    }
-
-    """
-    seq_len = tf.shape(X)[1]
-    bs = tf.shape(X)[0]
-
-    mask = tf.expand_dims(
-        tf.sequence_mask(sequence_lengths, maxlen=seq_len), 0
-    )  # 1, batch, seq
-    range = tf.expand_dims(
-        tf.expand_dims(tf.range(tf.reduce_max(end) + 1, dtype=start.dtype), 1), 1
-    )  # num_cols, 1, 1
-    start = tf.expand_dims(start, 0)  # 1, batch, max_len
-    end = tf.expand_dims(end, 0)  # 1, batch, max_len
-    col_masks = tf.math.logical_and(
-        tf.math.logical_and(
-            tf.math.less_equal(start, range), tf.math.less_equal(range, end)
-        ),
-        mask,
-    )  # num_cols, batch, seq
-
-    batch_idx = tf.tile(tf.expand_dims(tf.range(bs), 1), [1, seq_len])
-    seq_idx = tf.tile(tf.expand_dims(tf.range(seq_len), 0), [bs, 1])
-    scatter_idx_orig = tf.stack([batch_idx, seq_idx], axis=-1)  # batch, seq, 2
-    scatter_idx_orig = tf.reshape(scatter_idx_orig, [bs, seq_len, 2])
-    return slice_by_table_indices(
-        scatter_idx_orig,
-        col_masks,
-        tf.convert_to_tensor([0, seq_len]),
-        tf.convert_to_tensor([0, seq_len + 1]),
-        pad_val=tf.convert_to_tensor([0, seq_len + 2]),
-        other_end=other_end,
-        include_mask=True,
-        chunk_tables=chunk_tables,
-    )
-
-
-def batch_packing(ragged_input, include_mask=True, base_model_max_length=512, training=False):
+def batch_packing(
+    ragged_input,
+    include_mask=True,
+    base_model_max_length=512,
+    training=False,
+    target_seq_len=None,
+):
     """
     Takes a ragged tensor input and re-packs the batches to minimise the batch size without
     impacting the sequence length. Additionally returns a mask to use with self-attention so
@@ -85,8 +30,8 @@ def batch_packing(ragged_input, include_mask=True, base_model_max_length=512, tr
 
     # If there is some fast way to sort the rows of a ragged tensor we might consider doing this first.
     col_seq_lens = ragged_input.row_lengths()
-    if training:
-        max_length = tf.cast(get_target_length(), tf.int64)
+    if training and target_seq_len is not None:
+        max_length = tf.cast(target_seq_len, tf.int64)
     else:
         max_length = tf.minimum(tf.reduce_max(col_seq_lens), base_model_max_length)
 
@@ -220,52 +165,43 @@ def chunk_ragged_tensor(
     result = tf.concat([first_n_rows_duped, other_rows_reshaped], 1)
     return result
 
-def get_target_length() -> int:
-    return 512
 
-@tf.function(autograph=True)
-def get_target_batch_size(lengths: tf.Tensor) -> int:
-    batch_size = tf.shape(lengths)[0]
-    if batch_size <= 8:
-        return 8
-     # We should never really hit this. But just as a fallback because we are liable to lose data otherwise.
-    tf.print("Patch packing resulted in a batch size of", batch_size, "Which is more than our default target of 8. This will result in slower training.", summarize=-1)
-    return batch_size
-
-def slice_by_table_indices(
-    inp,
-    col_masks,
-    eos_pad,
-    bos_pad,
-    pad_val,
+def compute_masked_ragged_indices(
+    X,
+    sequence_lengths,
+    start,
+    end,
     other_end,
+    chunk_tables,
     base_model_max_length=512,
-    max_tokens_per_batch=512 * 100,
-    check_len=False,
-    include_mask=False,
-    chunk_tables=True,
-    training=True
 ):
-    """
-    Used internally by get_gather_indices - assumes that any pre-processing of adding special tokens is already complete.
-    Can handle higher rank inputs but it seems to be quicker to just generate the indices and then gather.
-    """
+    """Build masked ragged indices for table rows/cols with optional chunking."""
     with tf.device("cpu"):
-        bos_pad_ragged = tf.RaggedTensor.from_tensor(
-            tf.expand_dims(tf.expand_dims(bos_pad, 0), 0)
-        )
-        eos_pad_ragged = tf.RaggedTensor.from_tensor(
-            tf.expand_dims(tf.expand_dims(eos_pad, 0), 0)
-        )
+        bs = tf.shape(X)[0]
+        seq_len = tf.shape(X)[1]
+        mask = tf.expand_dims(
+            tf.sequence_mask(sequence_lengths, maxlen=seq_len), 0
+        )  # 1, batch, seq
+        range_ = tf.expand_dims(
+            tf.expand_dims(tf.range(tf.reduce_max(end) + 1, dtype=start.dtype), 1), 1
+        )  # num_cols, 1, 1
+        start_e = tf.expand_dims(start, 0)  # 1, batch, max_len
+        end_e = tf.expand_dims(end, 0)  # 1, batch, max_len
+        col_masks = tf.math.logical_and(
+            tf.math.logical_and(tf.math.less_equal(start_e, range_), tf.math.less_equal(range_, end_e)),
+            mask,
+        )  # num_cols, batch, seq
 
-        inp_expanded = tf.expand_dims(inp, 0)  # 1, bs, seq, ...
+        batch_idx = tf.tile(tf.expand_dims(tf.range(bs), 1), [1, seq_len])
+        seq_idx = tf.tile(tf.expand_dims(tf.range(seq_len), 0), [bs, 1])
+        scatter_idx_orig = tf.stack([batch_idx, seq_idx], axis=-1)  # batch, seq, 2
+
+        inp_expanded = tf.expand_dims(scatter_idx_orig, 0)  # 1, bs, seq, 2
+        
         inp_values_i = tf.ragged.boolean_mask(
-            tf.tile(
-                inp_expanded,
-                [tf.shape(col_masks)[0], 1, 1, *(1 for _ in bos_pad.shape)],
-            ),
-            col_masks,
+            tf.tile(inp_expanded, [tf.shape(col_masks)[0], 1, 1, 1]), col_masks
         ).merge_dims(0, 1)
+
         batch_mask = tf.math.not_equal(inp_values_i.row_lengths(), 0)
         inp_values = tf.RaggedTensor.from_row_lengths(
             values=inp_values_i.flat_values,
@@ -273,29 +209,62 @@ def slice_by_table_indices(
         )
         if chunk_tables:
             inp_values = chunk_ragged_tensor(
-                inp_values,
-                other_end=other_end,
-                base_model_max_length=base_model_max_length - 2,
-            )  # -2 for eos and bos
+                inp_values, other_end=other_end, base_model_max_length=base_model_max_length - 2
+            )  # -2 for EOS and BOS
+                # Prepare BOS/EOS paddings
+        bos_pad = tf.convert_to_tensor([0, seq_len + 1])
+        eos_pad = tf.convert_to_tensor([0, seq_len])
+
+        bos_pad_ragged = tf.RaggedTensor.from_tensor(
+            tf.expand_dims(tf.expand_dims(bos_pad, 0), 0)
+        )
+        eos_pad_ragged = tf.RaggedTensor.from_tensor(
+            tf.expand_dims(tf.expand_dims(eos_pad, 0), 0)
+        )
+
         col_bs = tf.shape(inp_values.row_lengths())[0]
-        bos_expanded = tf.tile(bos_pad_ragged, [col_bs, 1, *(1 for _ in bos_pad.shape)])
-        eos_expanded = tf.tile(eos_pad_ragged, [col_bs, 1, *(1 for _ in eos_pad.shape)])
+        bos_expanded = tf.tile(bos_pad_ragged, [col_bs, 1, 1])
+        eos_expanded = tf.tile(eos_pad_ragged, [col_bs, 1, 1])
         output_ragged = tf.concat([bos_expanded, inp_values, eos_expanded], axis=1)
+    return output_ragged
+
+
+def build_gather_outputs(
+    X,
+    sequence_lengths,
+    start,
+    end,
+    other_end,
+    chunk_tables,
+    include_mask,
+    training,
+    target_seq_len=None,
+    target_batch_size=None,
+    base_model_max_length=512,
+    max_tokens_per_batch=512 * 100,
+    check_len=False,
+):
+    with tf.device("cpu"):
+        output_ragged = compute_masked_ragged_indices(
+            X, sequence_lengths, start, end, other_end, chunk_tables, base_model_max_length
+        )
+        pad_val = tf.convert_to_tensor([0, tf.shape(X)[1] + 2])
         output_ragged, mask, pos_ids = batch_packing(
             output_ragged,
             include_mask=include_mask,
             base_model_max_length=base_model_max_length,
             training=training,
+            target_seq_len=target_seq_len,
         )
         col_seq_lens = output_ragged.row_lengths()
 
-        # I don't think this default matters here as these are masked. Cannot be < 0
+        # Convert to dense tensor of shape [None, None, 2]
         col_values = output_ragged.to_tensor(
-            default_value=pad_val, shape=[None, None] + inp.shape[2:]
+            default_value=pad_val, shape=[None, None, 2]
         )
         pos_ids = pos_ids.to_tensor(default_value=0, shape=[None, None])
-    # This is to handle some edge cases where 0 length values are missing the final dim after conversion.
-    col_values.set_shape([None, None] + list(inp.shape[2:]))
+
+    # Crop if not chunking
     max_length = tf.minimum(
         tf.math.floordiv(max_tokens_per_batch, tf.shape(col_values)[0]),
         base_model_max_length,
@@ -326,30 +295,28 @@ def slice_by_table_indices(
                 mask.set_shape([None, None, None])
             pos_ids = pos_ids[:, :max_length]
 
+    # Casts and shapes
     col_seq_lens = tf.cast(col_seq_lens, tf.int32)
     pos_ids = tf.cast(pos_ids, tf.int32)
-    if training:
-        target_seq_len = get_target_length()
-        target_batch_size = get_target_batch_size(col_seq_lens)
 
-        # Slice values that are too long
-        # Should be unnecessary as we have an effectively dynamic batch_size and fixed seq_len that is already enforced.
-        # col_values = col_values[:target_batch_size, :target_seq_len]
-        # mask = mask[:target_batch_size, :target_seq_len, :target_seq_len]
-        # pos_ids = pos_ids[:target_batch_size, :target_seq_len]
-        # col_seq_lens = tf.minimum(col_seq_lens[:target_batch_size], target_seq_len)
+    # Final adjustment to exact target sequence length when training
+    if training and (target_seq_len is not None or target_batch_size is not None):
+        seq_padding = tf.maximum(target_seq_len - tf.shape(col_values)[1], 0)
+        batch_padding = tf.maximum(target_batch_size - tf.shape(col_values)[0], 0)
+        pad0 = tf.pad(
+            col_values[:, :target_seq_len, 0], [[0, batch_padding], [0, seq_padding]], constant_values=pad_val[0]
+        )
+        pad1 = tf.pad(
+            col_values[:, :target_seq_len, 1], [[0, batch_padding], [0, seq_padding]], constant_values=pad_val[1]
+        )
+        col_values = tf.stack([pad0, pad1], axis=-1)
+        if include_mask:
+            mask = tf.pad(
+                mask[:, :target_seq_len, :target_seq_len], [[0, batch_padding], [0, seq_padding], [0, seq_padding]], constant_values=0
+            )
+        pos_ids = tf.pad(pos_ids[:, :target_seq_len], [[0, batch_padding], [0, seq_padding]], constant_values=0)
 
-        # Pad any values that are too short.
-        seq_padding = target_seq_len - tf.shape(col_values)[1]
-        batch_padding = target_batch_size - tf.shape(col_values)[0]
-        col_seq_lens = tf.pad(col_seq_lens, [[0, batch_padding]], constant_values=0)
-        col_values_0 = tf.pad(col_values[:, :, 0], [[0, batch_padding], [0, seq_padding]], constant_values=pad_val[0])
-        col_values_1 = tf.pad(col_values[:, :, 1], [[0, batch_padding], [0, seq_padding]], constant_values=pad_val[1])
-        col_values = tf.stack([col_values_0, col_values_1], axis=-1)
-        mask = tf.pad(mask, [[0, batch_padding], [0, seq_padding], [0, seq_padding]], constant_values=0)
-        pos_ids = tf.pad(pos_ids, [[0, batch_padding], [0, seq_padding]], constant_values=0)
-
-    col_values.set_shape([None, None] + list(inp.shape[2:]))
+    col_values.set_shape([None, None, 2])
     return {
         "seq_lens": col_seq_lens,
         "values": col_values,
@@ -488,13 +455,14 @@ def scatter_feats(output_shape, sequence_feats, scatter_vals):
     # Special tokens were placed after the length of the shape.
     feats = tf.boolean_mask(sequence_feats, mask)  # [None, feat_dim]
     scatter_idxs = tf.boolean_mask(scatter_vals, mask)  # [None, 2]
-    # Averages any cases where tokens are in multiple cells - for example when cells span multiple rows / cols.
+    # # Averages any cases where tokens are in multiple cells - for example when cells span multiple rows / cols.
     divide_by = tf.tensor_scatter_nd_add(
         input_tensor, scatter_idxs, tf.ones_like(feats)
     )  # [text_batch, text_seq, feat_dim]
     return tf.math.divide_no_nan(
         tf.tensor_scatter_nd_add(input_tensor, scatter_idxs, feats), divide_by
     )  # [text_batch, text_seq, feat_dim]
+   
 
 
 def get_summary_values(inp, gather_vals, input_seq_len):
@@ -551,3 +519,189 @@ def reassemble_sequence_feats(
         feats = tf.compat.v1.layers.dense(feats, 768, activation=gelu)
 
     return feats
+
+class TableModelBatchPostprocessor:
+    def __init__(self, config=None):
+        self.config = config
+        self._cached_stats = None  # (row_len, col_len, row_bs, col_bs)
+
+    def modify_input_spec(self, input_spec):
+        (types, target_type), (shapes, target_shape) = input_spec
+        gather_shapes = {
+            "seq_lens": tf.TensorShape([None]),
+            "values": tf.TensorShape([None, None, 2]),
+            "attn_mask": tf.TensorShape([None, None, None]),
+            "pos_ids": tf.TensorShape([None, None]),
+        }
+        gather_types = {
+            "seq_lens": tf.int32,
+            "values": tf.int32,
+            "attn_mask": tf.float32,
+            "pos_ids": tf.int32,
+        }
+        shapes["row_gather"] = gather_shapes
+        shapes["col_gather"] = gather_shapes
+        types["row_gather"] = gather_types
+        types["col_gather"] = gather_types
+        return (types, target_type), (shapes, target_shape)
+
+    def _postprocess(self, x, y=None, target_row_len=None, target_col_len=None, target_row_batch_size=None, target_col_batch_size=None, training=True):
+        # Should run on cpu anyway but just to be safe.
+        with tf.device("/CPU:0"):
+            end_col, end_row, start_col, start_row = tf.unstack(
+                tf.cast(x["context"], tf.int32), num=4, axis=2
+            )
+            # Get gather indices for rows and columns
+            row_gather = build_gather_outputs(
+                X=x["tokens"],
+                sequence_lengths=x["length"],
+                start=start_row,
+                end=end_row,
+                other_end=end_col,
+                chunk_tables=self.config.chunk_tables,
+                include_mask=True,
+                training=training,
+                target_seq_len=target_row_len,
+                target_batch_size=target_row_batch_size,
+                base_model_max_length=self.config.max_length,
+            )
+            col_gather = build_gather_outputs(
+                X=x["tokens"],
+                sequence_lengths=x["length"],
+                start=start_col,
+                end=end_col,
+                other_end=end_row,
+                chunk_tables=self.config.chunk_tables,
+                include_mask=True,
+                training=training,
+                target_seq_len=target_col_len,
+                target_batch_size=target_col_batch_size,
+                base_model_max_length=self.config.max_length,
+            )
+            x = {**x, "row_gather": row_gather, "col_gather": col_gather}
+            if y is not None:
+                return x, y
+            return x
+
+    # Backward-compatible default mapping fn (assumes training semantics)
+    def postprocess(self, x, y=None):
+        return self._postprocess(x, y=y, training=True)
+
+    def get_dataset_transform(self, mode="train"):
+        assert mode in {"train", "predict"}
+
+        def _transform(ds):
+            # For training, scan dataset to set global target lengths/batch sizes
+            if mode == "train":
+                # If we already computed stats for this postprocessor, just reuse them
+                if self._cached_stats is None:
+                    LOGGER.info("Running down 1 epoch of the dataset to calculate optimal batch size and sequence length for table model.")
+                    def _stats_map(*args):
+                        if len(args) == 2:
+                            x, _y = args
+                        else:
+                            (x,) = args
+                        end_col, end_row, start_col, start_row = tf.unstack(
+                            tf.cast(x["context"], tf.int32), num=4, axis=2
+                        )
+                        ragged_rows = compute_masked_ragged_indices(
+                            x["tokens"],
+                            x["length"],
+                            start_row,
+                            end_row,
+                            other_end=end_col,
+                            chunk_tables=self.config.chunk_tables,
+                            base_model_max_length=self.config.max_length,
+                        )
+                        ragged_cols = compute_masked_ragged_indices(
+                            x["tokens"],
+                            x["length"],
+                            start_col,
+                            end_col,
+                            other_end=end_row,
+                            chunk_tables=self.config.chunk_tables,
+                            base_model_max_length=self.config.max_length,
+                        )
+                        return ragged_rows, ragged_cols
+
+                    ragged_values = (
+                        ds.map(_stats_map, num_parallel_calls=tf.data.AUTOTUNE, deterministic=False)
+                    )
+
+                    # Compute maxima across the bounded window
+                    max_row_seq_len = 0
+                    max_col_seq_len = 0
+                    for ragged_rows, ragged_cols in ragged_values:
+                        max_row_seq_len = max(
+                            max_row_seq_len, int(tf.reduce_max(ragged_rows.row_lengths()).numpy())
+                        )
+                        max_col_seq_len = max(
+                            max_col_seq_len, int(tf.reduce_max(ragged_cols.row_lengths()).numpy())
+                        )
+
+                    # Compute packed batch sizes using those maxima
+                    def _batch_packing_map(ragged_rows, ragged_cols):
+                        repacked_rows, _, _ = batch_packing(
+                            ragged_rows,
+                            include_mask=False,
+                            training=True,
+                            target_seq_len=max_row_seq_len,
+                        )
+                        repacked_cols, _, _ = batch_packing(
+                            ragged_cols,
+                            include_mask=False,
+                            training=True,
+                            target_seq_len=max_col_seq_len,
+                        )
+                        return tf.shape(repacked_rows)[0], tf.shape(repacked_cols)[0]
+
+                    row_batch_size = 0
+                    col_batch_size = 0
+                    for row_bs, col_bs in ragged_values.map(
+                        _batch_packing_map, num_parallel_calls=tf.data.AUTOTUNE
+                    ):
+                        row_batch_size = max(row_batch_size, int(row_bs.numpy()))
+                        col_batch_size = max(col_batch_size, int(col_bs.numpy()))
+
+                    self._cached_stats = (
+                        int(max_row_seq_len),
+                        int(max_col_seq_len),
+                        int(row_batch_size),
+                        int(col_batch_size),
+                    )
+                    LOGGER.info(f"Completed calculating stats. Cached stats: {self._cached_stats}")
+                else:
+                    LOGGER.info("Reusing cached stats")
+
+                # Unpack cached stats
+                max_row_seq_len, max_col_seq_len, row_batch_size, col_batch_size = self._cached_stats
+                target_col_batch_size = tf.convert_to_tensor(col_batch_size, dtype=tf.int32)
+                target_row_batch_size = tf.convert_to_tensor(row_batch_size, dtype=tf.int32)
+                target_col_len = tf.convert_to_tensor(max_col_seq_len, dtype=tf.int32)
+                target_row_len = tf.convert_to_tensor(max_row_seq_len, dtype=tf.int32)
+
+                def _train_map(*args):
+                    if len(args) == 2:
+                        x, y = args
+                    else:
+                        (x,) = args
+                        y = None
+                    return self._postprocess(
+                        x,
+                        y=y,
+                        target_row_len=target_row_len,
+                        target_col_len=target_col_len,
+                        target_row_batch_size=target_row_batch_size,
+                        target_col_batch_size=target_col_batch_size,
+                        training=True
+                    )
+
+                return ds.map(_train_map, num_parallel_calls=tf.data.AUTOTUNE)
+
+            # Predict/test mode: use dynamic packing; no pre-scan
+            return ds.map(
+                lambda *args: self._postprocess(*args, training=False),
+                num_parallel_calls=tf.data.AUTOTUNE,
+            )
+
+        return _transform

--- a/finetune/base_models/bert/table_utils.py
+++ b/finetune/base_models/bert/table_utils.py
@@ -66,7 +66,7 @@ def get_gather_indices(X, sequence_lengths, start, end, other_end, chunk_tables)
     )
 
 
-def batch_packing(ragged_input, include_mask=True, base_model_max_length=512):
+def batch_packing(ragged_input, include_mask=True, base_model_max_length=512, training=False):
     """
     Takes a ragged tensor input and re-packs the batches to minimise the batch size without
     impacting the sequence length. Additionally returns a mask to use with self-attention so
@@ -85,7 +85,10 @@ def batch_packing(ragged_input, include_mask=True, base_model_max_length=512):
 
     # If there is some fast way to sort the rows of a ragged tensor we might consider doing this first.
     col_seq_lens = ragged_input.row_lengths()
-    max_length = tf.minimum(tf.reduce_max(col_seq_lens), base_model_max_length)
+    if training:
+        max_length = tf.cast(get_target_length(), tf.int64)
+    else:
+        max_length = tf.minimum(tf.reduce_max(col_seq_lens), base_model_max_length)
 
     def loop_body(l, i):
         temp_ragged = tf.RaggedTensor.from_row_lengths(
@@ -217,6 +220,17 @@ def chunk_ragged_tensor(
     result = tf.concat([first_n_rows_duped, other_rows_reshaped], 1)
     return result
 
+def get_target_length() -> int:
+    return 512
+
+@tf.function(autograph=True)
+def get_target_batch_size(lengths: tf.Tensor) -> int:
+    batch_size = tf.shape(lengths)[0]
+    if batch_size <= 8:
+        return 8
+     # We should never really hit this. But just as a fallback because we are liable to lose data otherwise.
+    tf.print("Patch packing resulted in a batch size of", batch_size, "Which is more than our default target of 8. This will result in slower training.", summarize=-1)
+    return batch_size
 
 def slice_by_table_indices(
     inp,
@@ -230,6 +244,7 @@ def slice_by_table_indices(
     check_len=False,
     include_mask=False,
     chunk_tables=True,
+    training=True
 ):
     """
     Used internally by get_gather_indices - assumes that any pre-processing of adding special tokens is already complete.
@@ -266,11 +281,11 @@ def slice_by_table_indices(
         bos_expanded = tf.tile(bos_pad_ragged, [col_bs, 1, *(1 for _ in bos_pad.shape)])
         eos_expanded = tf.tile(eos_pad_ragged, [col_bs, 1, *(1 for _ in eos_pad.shape)])
         output_ragged = tf.concat([bos_expanded, inp_values, eos_expanded], axis=1)
-
         output_ragged, mask, pos_ids = batch_packing(
             output_ragged,
             include_mask=include_mask,
             base_model_max_length=base_model_max_length,
+            training=training,
         )
         col_seq_lens = output_ragged.row_lengths()
 
@@ -311,12 +326,35 @@ def slice_by_table_indices(
                 mask.set_shape([None, None, None])
             pos_ids = pos_ids[:, :max_length]
 
+    col_seq_lens = tf.cast(col_seq_lens, tf.int32)
+    pos_ids = tf.cast(pos_ids, tf.int32)
+    if training:
+        target_seq_len = get_target_length()
+        target_batch_size = get_target_batch_size(col_seq_lens)
+
+        # Slice values that are too long
+        # Should be unnecessary as we have an effectively dynamic batch_size and fixed seq_len that is already enforced.
+        # col_values = col_values[:target_batch_size, :target_seq_len]
+        # mask = mask[:target_batch_size, :target_seq_len, :target_seq_len]
+        # pos_ids = pos_ids[:target_batch_size, :target_seq_len]
+        # col_seq_lens = tf.minimum(col_seq_lens[:target_batch_size], target_seq_len)
+
+        # Pad any values that are too short.
+        seq_padding = target_seq_len - tf.shape(col_values)[1]
+        batch_padding = target_batch_size - tf.shape(col_values)[0]
+        col_seq_lens = tf.pad(col_seq_lens, [[0, batch_padding]], constant_values=0)
+        col_values_0 = tf.pad(col_values[:, :, 0], [[0, batch_padding], [0, seq_padding]], constant_values=pad_val[0])
+        col_values_1 = tf.pad(col_values[:, :, 1], [[0, batch_padding], [0, seq_padding]], constant_values=pad_val[1])
+        col_values = tf.stack([col_values_0, col_values_1], axis=-1)
+        mask = tf.pad(mask, [[0, batch_padding], [0, seq_padding], [0, seq_padding]], constant_values=0)
+        pos_ids = tf.pad(pos_ids, [[0, batch_padding], [0, seq_padding]], constant_values=0)
+
     col_values.set_shape([None, None] + list(inp.shape[2:]))
     return {
-        "seq_lens": tf.cast(col_seq_lens, tf.int32),
+        "seq_lens": col_seq_lens,
         "values": col_values,
         "attn_mask": mask,
-        "pos_ids": tf.cast(pos_ids, tf.int32),
+        "pos_ids": pos_ids,
     }
 
 
@@ -338,15 +376,6 @@ def gather_col_vals(inp, gather_output, eos_pad, bos_pad, pad_val):
             "attn_mask": mask from gather output unmodified,
         }
     """
-    # bs = tf.shape(inp)[0]
-    # bos_expanded = tf.tile(
-    #     tf.expand_dims(tf.expand_dims(bos_pad, 0), 0),
-    #     [bs, 1, *(1 for _ in bos_pad.shape)],
-    # )
-    # eos_expanded = tf.tile(
-    #     tf.expand_dims(tf.expand_dims(eos_pad, 0), 0),
-    #     [bs, 1, *(1 for _ in eos_pad.shape)],
-    # )
     hidden_dim = inp.shape[2:]
     batch_size = tf.shape(inp)[0]
     token_bcast_shape = [batch_size, 1, *hidden_dim]

--- a/finetune/base_models/bert/table_utils.py
+++ b/finetune/base_models/bert/table_utils.py
@@ -316,26 +316,46 @@ def build_gather_outputs(
         seq_padding = tf.maximum(target_seq_len - tf.shape(col_values)[1], 0)
         batch_padding = tf.maximum(target_batch_size - tf.shape(col_values)[0], 0)
         pad0 = tf.pad(
-            col_values[:, :target_seq_len, 0],
+            col_values[:target_batch_size, :target_seq_len, 0],
             [[0, batch_padding], [0, seq_padding]],
             constant_values=pad_val[0],
         )
         pad1 = tf.pad(
-            col_values[:, :target_seq_len, 1],
+            col_values[:target_batch_size, :target_seq_len, 1],
             [[0, batch_padding], [0, seq_padding]],
             constant_values=pad_val[1],
         )
-        col_values = tf.stack([pad0, pad1], axis=-1)
+        # The ensure shapes will raise an error if the shapes don't match. But we are being
+        # very defensive here so it should be fine and variations will make train time / memory explode
+        # if we get this even slightly wrong.
+        col_values = tf.ensure_shape(
+            tf.stack([pad0, pad1], axis=-1),
+            [target_batch_size, target_seq_len, 2],
+        )
         if include_mask:
-            mask = tf.pad(
-                mask[:, :target_seq_len, :target_seq_len],
-                [[0, batch_padding], [0, seq_padding], [0, seq_padding]],
-                constant_values=0,
+            mask = tf.ensure_shape(
+                tf.pad(
+                    mask[:target_batch_size, :target_seq_len, :target_seq_len],
+                    [[0, batch_padding], [0, seq_padding], [0, seq_padding]],
+                    constant_values=0,
+                ),
+                [target_batch_size, target_seq_len, target_seq_len],
             )
-        pos_ids = tf.pad(
-            pos_ids[:, :target_seq_len],
-            [[0, batch_padding], [0, seq_padding]],
-            constant_values=0,
+        pos_ids = tf.ensure_shape(
+            tf.pad(
+                pos_ids[:target_batch_size, :target_seq_len],
+                [[0, batch_padding], [0, seq_padding]],
+                constant_values=0,
+            ),
+            [target_batch_size, target_seq_len],
+        )
+        col_seq_lens = tf.ensure_shape(
+            tf.pad(
+                col_seq_lens[:target_batch_size],
+                [[0, batch_padding]],
+                constant_values=0,
+            ),
+            [target_batch_size],
         )
 
     col_values.set_shape([None, None, 2])

--- a/finetune/config.py
+++ b/finetune/config.py
@@ -322,6 +322,7 @@ def get_default_config():
         max_row_col_embedding=1024,
         chunk_tables=False,
         table_batching=False,
+        extra_data_epochs=0,
         # chunking_tweaks
         reshuffle_chunks=False,
         predict_chunk_markers=False,

--- a/finetune/input_pipeline.py
+++ b/finetune/input_pipeline.py
@@ -18,7 +18,6 @@ from finetune.util.input_utils import (
     Chunker,
     InputMode,
     batch_dataset,
-    has_targets,
     wrap_tqdm,
 )
 
@@ -36,12 +35,19 @@ class BasePipeline(metaclass=ABCMeta):
         self._chunker = None
         self.current_epoch_offset = 0
         self.total_epoch_offset = 0
+        self._batch_postprocessor = None
 
     @property
     def text_encoder(self):
         if not hasattr(self, "_text_encoder") or self._text_encoder is None:
             self._text_encoder = self.config.base_model.get_encoder(self.config)
         return self._text_encoder
+
+    @property
+    def batch_postprocessor(self):
+        if not hasattr(self, "_batch_postprocessor") or self._batch_postprocessor is None:
+            self._batch_postprocessor = self.config.base_model.get_batch_postprocessor(self.config)
+        return self._batch_postprocessor
 
     @property
     def dataset_size(self):
@@ -76,7 +82,7 @@ class BasePipeline(metaclass=ABCMeta):
         return (tf.int32, tf.TensorShape([self.target_dim]))
 
     def input_spec(
-        self, *, concrete_dims, include_lengths=True, batched=True, include_targets=True
+        self, *, concrete_dims, include_lengths=True, batched=True, include_targets=True, include_postprocessed=False
     ):
         TS = tf.TensorShape
         types = {"tokens": tf.int32}
@@ -101,6 +107,8 @@ class BasePipeline(metaclass=ABCMeta):
             )
         else:
             output = ((types, target_type), (shapes, target_shape))
+        if include_postprocessed:
+            output = self.batch_postprocessor.modify_input_spec(output)
         if not include_targets:
             (types, _), (shapes, _) = output
             output = (types, shapes)
@@ -108,17 +116,17 @@ class BasePipeline(metaclass=ABCMeta):
 
     def keras_input_def(self, *, concrete_dims, include_targets=False):
         input_types, input_shapes = self.input_spec(
-            concrete_dims=concrete_dims, include_targets=include_targets, batched=False
+            concrete_dims=concrete_dims, include_targets=include_targets, batched=True, include_postprocessed=True
         )
         return tf.nest.map_structure(
-            lambda dtype, shape: tf.keras.Input(shape=shape, dtype=dtype),
+            lambda dtype, shape: tf.keras.Input(batch_shape=shape, dtype=dtype),
             input_types,
             input_shapes,
         )
 
     def keras_input_signature(self, *, concrete_dims, include_targets):
         input_types, input_shapes = self.input_spec(
-            concrete_dims=concrete_dims, include_targets=include_targets
+            concrete_dims=concrete_dims, include_targets=include_targets, include_postprocessed=True
         )
         return tf.nest.map_structure(
             lambda dtype, shape: tf.TensorSpec(shape=shape, dtype=dtype),
@@ -246,6 +254,7 @@ class BasePipeline(metaclass=ABCMeta):
                 table_batching=False,  # We cannot use table batching here because the order of the outputs is impacted.
                 shapes=shapes,
                 drop_remainder=False,
+                batch_postprocessor=self.batch_postprocessor,
             )
         }
 
@@ -306,6 +315,7 @@ class BasePipeline(metaclass=ABCMeta):
             table_batching=self.config.table_batching,
             random_seed=self.config.seed,
             drop_remainder=True,
+            batch_postprocessor=self.batch_postprocessor,
         )
         return {
             "train_dataset": batched_train_dataset,

--- a/finetune/input_pipeline.py
+++ b/finetune/input_pipeline.py
@@ -218,6 +218,7 @@ class BasePipeline(metaclass=ABCMeta):
                 total_epoch_offset=self.total_epoch_offset
                 if tqdm_mode == "train"
                 else 0,
+                extra_data_epochs=self.config.extra_data_epochs if tqdm_mode == "train" else 0,
             ),
             types,
             shapes,

--- a/finetune/input_pipeline.py
+++ b/finetune/input_pipeline.py
@@ -23,6 +23,8 @@ from finetune.util.input_utils import (
 
 LOGGER = logging.getLogger("finetune")
 
+_SENTINEL = object()
+
 
 class BasePipeline(metaclass=ABCMeta):
     def __init__(self, config):
@@ -35,7 +37,7 @@ class BasePipeline(metaclass=ABCMeta):
         self._chunker = None
         self.current_epoch_offset = 0
         self.total_epoch_offset = 0
-        self._batch_postprocessor = None
+        self._batch_postprocessor = _SENTINEL
 
     @property
     def text_encoder(self):
@@ -45,7 +47,7 @@ class BasePipeline(metaclass=ABCMeta):
 
     @property
     def batch_postprocessor(self):
-        if not hasattr(self, "_batch_postprocessor") or self._batch_postprocessor is None:
+        if not hasattr(self, "_batch_postprocessor") or self._batch_postprocessor is _SENTINEL:
             self._batch_postprocessor = self.config.base_model.get_batch_postprocessor(self.config)
         return self._batch_postprocessor
 
@@ -110,7 +112,7 @@ class BasePipeline(metaclass=ABCMeta):
             )
         else:
             output = ((types, target_type), (shapes, target_shape))
-        if include_postprocessed:
+        if include_postprocessed and self.batch_postprocessor is not None:
             output = self.batch_postprocessor.modify_input_spec(output)
         if not include_targets:
             (types, _), (shapes, _) = output

--- a/finetune/input_pipeline.py
+++ b/finetune/input_pipeline.py
@@ -23,10 +23,11 @@ from finetune.util.input_utils import (
 
 LOGGER = logging.getLogger("finetune")
 
-_SENTINEL = object()
-
 
 class BasePipeline(metaclass=ABCMeta):
+     # We cannot use an object() sentinel here because of the way tensorflow handles it's processes breaks the 'is' check.
+    MISSING_BATCH_POSTPROCESSOR = "missing"
+
     def __init__(self, config):
         self.config = config
         self._text_encoder = None
@@ -37,7 +38,7 @@ class BasePipeline(metaclass=ABCMeta):
         self._chunker = None
         self.current_epoch_offset = 0
         self.total_epoch_offset = 0
-        self._batch_postprocessor = _SENTINEL
+        self._batch_postprocessor = self.MISSING_BATCH_POSTPROCESSOR
 
     @property
     def text_encoder(self):
@@ -47,7 +48,7 @@ class BasePipeline(metaclass=ABCMeta):
 
     @property
     def batch_postprocessor(self):
-        if not hasattr(self, "_batch_postprocessor") or self._batch_postprocessor is _SENTINEL:
+        if not hasattr(self, "_batch_postprocessor") or self._batch_postprocessor == self.MISSING_BATCH_POSTPROCESSOR:
             self._batch_postprocessor = self.config.base_model.get_batch_postprocessor(self.config)
         return self._batch_postprocessor
 

--- a/finetune/input_pipeline.py
+++ b/finetune/input_pipeline.py
@@ -14,18 +14,13 @@ from sklearn.utils import shuffle as dataset_shuffle
 from finetune.encoding.input_encoder import EncodedOutput, tokenize_context
 from finetune.errors import FinetuneError
 from finetune.util.imbalance import compute_class_weights
-from finetune.util.input_utils import (
-    Chunker,
-    InputMode,
-    batch_dataset,
-    wrap_tqdm,
-)
+from finetune.util.input_utils import Chunker, InputMode, batch_dataset, wrap_tqdm
 
 LOGGER = logging.getLogger("finetune")
 
 
 class BasePipeline(metaclass=ABCMeta):
-     # We cannot use an object() sentinel here because of the way tensorflow handles it's processes breaks the 'is' check.
+    # We cannot use an object() sentinel here because of the way tensorflow handles it's processes breaks the 'is' check.
     MISSING_BATCH_POSTPROCESSOR = "missing"
 
     def __init__(self, config):
@@ -48,8 +43,13 @@ class BasePipeline(metaclass=ABCMeta):
 
     @property
     def batch_postprocessor(self):
-        if not hasattr(self, "_batch_postprocessor") or self._batch_postprocessor == self.MISSING_BATCH_POSTPROCESSOR:
-            self._batch_postprocessor = self.config.base_model.get_batch_postprocessor(self.config)
+        if (
+            not hasattr(self, "_batch_postprocessor")
+            or self._batch_postprocessor == self.MISSING_BATCH_POSTPROCESSOR
+        ):
+            self._batch_postprocessor = self.config.base_model.get_batch_postprocessor(
+                self.config
+            )
         return self._batch_postprocessor
 
     @property
@@ -78,25 +78,35 @@ class BasePipeline(metaclass=ABCMeta):
         if self.config.use_auxiliary_info:
             TS = tf.TensorShape
             types["context"] = tf.float32
-            shapes["context"] = TS([self.config.max_length if concrete_dims else None, self.config.context_dim])
+            shapes["context"] = TS(
+                [
+                    self.config.max_length if concrete_dims else None,
+                    self.config.context_dim,
+                ]
+            )
         return types, shapes
 
     def target_def(self, concrete_dims):
         return (tf.int32, tf.TensorShape([self.target_dim]))
 
     def input_spec(
-        self, *, concrete_dims, include_lengths=True, batched=True, include_targets=True, include_postprocessed=False
+        self,
+        *,
+        concrete_dims,
+        include_lengths=True,
+        batched=True,
+        include_targets=True,
+        include_postprocessed=False
     ):
-        if self.config.table_batching:
-            # A model with table batching cannot have concrete dims because bucketing requires dynamic shapes.
-            concrete_dims = False
         TS = tf.TensorShape
         types = {"tokens": tf.int32}
         shapes = {"tokens": TS([self.config.max_length if concrete_dims else None])}
         if include_lengths:
             types["length"] = tf.int32
             shapes["length"] = TS([])
-        types, shapes = self._add_context_info_if_present(types, shapes, concrete_dims=concrete_dims)
+        types, shapes = self._add_context_info_if_present(
+            types, shapes, concrete_dims=concrete_dims
+        )
         target_type, target_shape = self.target_def(concrete_dims=concrete_dims)
         if batched:
             output = (
@@ -122,7 +132,10 @@ class BasePipeline(metaclass=ABCMeta):
 
     def keras_input_def(self, *, concrete_dims, include_targets=False):
         input_types, input_shapes = self.input_spec(
-            concrete_dims=concrete_dims, include_targets=include_targets, batched=True, include_postprocessed=True
+            concrete_dims=concrete_dims,
+            include_targets=include_targets,
+            batched=True,
+            include_postprocessed=True,
         )
         return tf.nest.map_structure(
             lambda dtype, shape: tf.keras.Input(batch_shape=shape, dtype=dtype),
@@ -132,7 +145,9 @@ class BasePipeline(metaclass=ABCMeta):
 
     def keras_input_signature(self, *, concrete_dims, include_targets):
         input_types, input_shapes = self.input_spec(
-            concrete_dims=concrete_dims, include_targets=include_targets, include_postprocessed=True
+            concrete_dims=concrete_dims,
+            include_targets=include_targets,
+            include_postprocessed=True,
         )
         return tf.nest.map_structure(
             lambda dtype, shape: tf.TensorSpec(shape=shape, dtype=dtype),
@@ -221,7 +236,9 @@ class BasePipeline(metaclass=ABCMeta):
                 total_epoch_offset=self.total_epoch_offset
                 if tqdm_mode == "train"
                 else 0,
-                extra_data_epochs=self.config.extra_data_epochs if tqdm_mode == "train" else 0,
+                extra_data_epochs=self.config.extra_data_epochs
+                if tqdm_mode == "train"
+                else 0,
             ),
             types,
             shapes,

--- a/finetune/input_pipeline.py
+++ b/finetune/input_pipeline.py
@@ -84,6 +84,9 @@ class BasePipeline(metaclass=ABCMeta):
     def input_spec(
         self, *, concrete_dims, include_lengths=True, batched=True, include_targets=True, include_postprocessed=False
     ):
+        if self.config.table_batching:
+            # A model with table batching cannot have concrete dims because bucketing requires dynamic shapes.
+            concrete_dims = False
         TS = tf.TensorShape
         types = {"tokens": tf.int32}
         shapes = {"tokens": TS([self.config.max_length if concrete_dims else None])}

--- a/finetune/model.py
+++ b/finetune/model.py
@@ -36,16 +36,16 @@ def get_keras_model(
 
         def call(self, data, **kwargs):
             LOGGER.debug("Tracing Model Function")
-            features: dict[str, tf.Tensor] = self.featurizer(
-                tokens=data["tokens"],
-                context=data.get("context", None),
-                sequence_lengths=data["length"],
-                **kwargs
-            )
+            # Also has tokens
+            data = dict(data) # Keras doesn't like it if we modify the dict in place
+            length = data.pop("length")
+            data["sequence_lengths"] = length
+            data["context"] = data.get("context", None)
+            features: dict[str, tf.Tensor] = self.featurizer(**data, **kwargs)
             # Unpack to include things like lengths
             if self.target_block is not None:
                 target_output: dict[str, tf.Tensor] = self.target_block(
-                    {**features, "length": data["length"]}  # , **data}
+                    {**features, "length": length}  # , **data}
                 )
             else:
                 target_output = {}

--- a/finetune/model.py
+++ b/finetune/model.py
@@ -36,8 +36,14 @@ def get_keras_model(
 
         def call(self, data, **kwargs):
             LOGGER.debug("Tracing Model Function")
-            # Also has tokens
-            data = dict(data) # Keras doesn't like it if we modify the dict in place
+            # Data contains:
+            # * tokens
+            # * length
+            # * context (optional - only for models with context)
+            # * row_gather (optional - only for the Table Model)
+            # * col_gather (optional - only for the Table Model)
+
+            data = dict(data)  # Keras doesn't like it if we modify the dict in place
             length = data.pop("length")
             data["sequence_lengths"] = length
             data["context"] = data.get("context", None)
@@ -45,7 +51,7 @@ def get_keras_model(
             # Unpack to include things like lengths
             if self.target_block is not None:
                 target_output: dict[str, tf.Tensor] = self.target_block(
-                    {**features, "length": length}  # , **data}
+                    {**features, "length": length}
                 )
             else:
                 target_output = {}

--- a/finetune/util/input_utils.py
+++ b/finetune/util/input_utils.py
@@ -95,7 +95,7 @@ def batch_dataset(
                 padded_shapes=shapes,
                 drop_remainder=drop_remainder,
             )
-            .map(batch_postprocessor.postprocess)
+            .map(batch_postprocessor.postprocess, num_parallel_calls=tf.data.AUTOTUNE)
             .repeat(n_epochs)
             .prefetch(tf.data.AUTOTUNE)
         )
@@ -103,13 +103,12 @@ def batch_dataset(
     else:
         return (
             dataset.map(add_length)
-            #            .map(expand_seq_to_multiple_of_16)
             .shuffle(500 if shuffle else 1, seed=random_seed)
             .repeat(n_epochs)
             .padded_batch(
                 batch_size, padded_shapes=shapes, drop_remainder=drop_remainder
             )
-            .map(batch_postprocessor.postprocess)
+            .map(batch_postprocessor.postprocess, num_parallel_calls=tf.data.AUTOTUNE)
             .prefetch(tf.data.AUTOTUNE)
         )
 

--- a/finetune/util/input_utils.py
+++ b/finetune/util/input_utils.py
@@ -64,15 +64,17 @@ def batch_dataset(
 ):
     if isinstance(shapes, tuple):
         shapes = ({**shapes[0], "length": tf.TensorShape([])}, shapes[1])
+        mode = "train"
     else:
         shapes = {**shapes, "length": tf.TensorShape([])}
+        mode = "predict"
 
     if table_batching:
         assert isinstance(
             shapes, tuple
         ), "You cannot use table batching to predict on tables as order is not guarenteed"
 
-        return (
+        dataset = (
             dataset.map(add_length)
             .shuffle(500 if shuffle else 1, seed=random_seed)
             # When we update to tf.2.13 this will change to be a method on the dataset.
@@ -95,22 +97,24 @@ def batch_dataset(
                 padded_shapes=shapes,
                 drop_remainder=drop_remainder,
             )
-            .map(batch_postprocessor.postprocess, num_parallel_calls=tf.data.AUTOTUNE)
-            .repeat(n_epochs)
-            .prefetch(tf.data.AUTOTUNE)
         )
+        if batch_postprocessor is not None:
+            dataset = dataset.apply(batch_postprocessor.get_dataset_transform(mode=mode))
+
+        return dataset.repeat(n_epochs).prefetch(tf.data.AUTOTUNE)
 
     else:
-        return (
+        dataset = (
             dataset.map(add_length)
             .shuffle(500 if shuffle else 1, seed=random_seed)
-            .repeat(n_epochs)
             .padded_batch(
                 batch_size, padded_shapes=shapes, drop_remainder=drop_remainder
             )
-            .map(batch_postprocessor.postprocess, num_parallel_calls=tf.data.AUTOTUNE)
-            .prefetch(tf.data.AUTOTUNE)
         )
+        if batch_postprocessor is not None:
+            dataset = dataset.apply(batch_postprocessor.get_dataset_transform(mode=mode))
+
+        return dataset.repeat(n_epochs).prefetch(tf.data.AUTOTUNE)
 
 
 def wrap_tqdm(
@@ -122,6 +126,7 @@ def wrap_tqdm(
     total_epoch_offset=0,
     quiet=False,
     update_hook=None,
+    extra_data_epochs=0,
 ):
     assert mode in {"train", "predict"}
     if mode == "predict":
@@ -133,13 +138,18 @@ def wrap_tqdm(
         total = dataset_size
     epoch = 1
 
+    n_epochs += extra_data_epochs
+
     def internal_gen():
         nonlocal epoch
-        current_epoch = (epoch - 1) % n_epochs + 1
+        current_epoch = (epoch - 1) % (n_epochs + 1)
         it = iter(gen())
-        desc = "Epoch {}/{}".format(
-            current_epoch + current_epoch_offset, n_epochs + total_epoch_offset
-        )
+        if current_epoch < extra_data_epochs:
+            desc = "Data Preprocessing"
+        else:
+            desc = "Epoch {}/{}".format(
+                current_epoch + current_epoch_offset + extra_data_epochs, n_epochs + total_epoch_offset - extra_data_epochs
+            )
         for i in ProgressBar(
             it,
             desc=desc,

--- a/finetune/util/input_utils.py
+++ b/finetune/util/input_utils.py
@@ -1,5 +1,6 @@
-import tensorflow as tf
 import typing as t
+
+import tensorflow as tf
 
 from finetune.util.timing import ProgressBar
 
@@ -75,8 +76,7 @@ def batch_dataset(
         ), "You cannot use table batching to predict on tables as order is not guarenteed"
 
         dataset = (
-            dataset.map(add_length)
-            .shuffle(500 if shuffle else 1, seed=random_seed)
+            dataset.map(add_length).shuffle(500 if shuffle else 1, seed=random_seed)
             # When we update to tf.2.13 this will change to be a method on the dataset.
             .bucket_by_sequence_length(
                 element_length_func=(
@@ -99,7 +99,9 @@ def batch_dataset(
             )
         )
         if batch_postprocessor is not None:
-            dataset = dataset.apply(batch_postprocessor.get_dataset_transform(mode=mode))
+            dataset = dataset.apply(
+                batch_postprocessor.get_dataset_transform(mode=mode)
+            )
 
         return dataset.repeat(n_epochs).prefetch(tf.data.AUTOTUNE)
 
@@ -112,7 +114,9 @@ def batch_dataset(
             )
         )
         if batch_postprocessor is not None:
-            dataset = dataset.apply(batch_postprocessor.get_dataset_transform(mode=mode))
+            dataset = dataset.apply(
+                batch_postprocessor.get_dataset_transform(mode=mode)
+            )
 
         return dataset.repeat(n_epochs).prefetch(tf.data.AUTOTUNE)
 
@@ -148,7 +152,8 @@ def wrap_tqdm(
             desc = "Data Preprocessing"
         else:
             desc = "Epoch {}/{}".format(
-                current_epoch + current_epoch_offset + extra_data_epochs, n_epochs + total_epoch_offset - extra_data_epochs
+                current_epoch + current_epoch_offset + extra_data_epochs,
+                n_epochs + total_epoch_offset - extra_data_epochs,
             )
         for i in ProgressBar(
             it,

--- a/finetune/util/input_utils.py
+++ b/finetune/util/input_utils.py
@@ -152,7 +152,7 @@ def wrap_tqdm(
             desc = "Data Preprocessing"
         else:
             desc = "Epoch {}/{}".format(
-                current_epoch + current_epoch_offset + extra_data_epochs,
+                current_epoch + current_epoch_offset - extra_data_epochs,
                 n_epochs + total_epoch_offset - extra_data_epochs,
             )
         for i in ProgressBar(

--- a/finetune/util/input_utils.py
+++ b/finetune/util/input_utils.py
@@ -76,8 +76,8 @@ def batch_dataset(
         ), "You cannot use table batching to predict on tables as order is not guarenteed"
 
         dataset = (
-            dataset.map(add_length).shuffle(500 if shuffle else 1, seed=random_seed)
-            # When we update to tf.2.13 this will change to be a method on the dataset.
+            dataset.map(add_length)
+            .shuffle(500 if shuffle else 1, seed=random_seed)
             .bucket_by_sequence_length(
                 element_length_func=(
                     lambda item, *_: tf.cast(

--- a/finetune/util/input_utils.py
+++ b/finetune/util/input_utils.py
@@ -1,4 +1,5 @@
 import tensorflow as tf
+import typing as t
 
 from finetune.util.timing import ProgressBar
 
@@ -59,6 +60,7 @@ def batch_dataset(
     table_batching: bool = False,
     random_seed: int = 42,
     drop_remainder: bool = False,
+    batch_postprocessor: t.Callable = None,
 ):
     if isinstance(shapes, tuple):
         shapes = ({**shapes[0], "length": tf.TensorShape([])}, shapes[1])
@@ -74,27 +76,26 @@ def batch_dataset(
             dataset.map(add_length)
             .shuffle(500 if shuffle else 1, seed=random_seed)
             # When we update to tf.2.13 this will change to be a method on the dataset.
-            .apply(
-                tf.data.experimental.bucket_by_sequence_length(
-                    element_length_func=(
-                        lambda item, *_: tf.cast(
-                            tf.maximum(
-                                tf.reduce_sum(
-                                    item["context"][:, 0] - item["context"][:, 2] + 1
-                                ),
-                                tf.reduce_sum(
-                                    item["context"][:, 1] - item["context"][:, 3] + 1
-                                ),
+            .bucket_by_sequence_length(
+                element_length_func=(
+                    lambda item, *_: tf.cast(
+                        tf.maximum(
+                            tf.reduce_sum(
+                                item["context"][:, 0] - item["context"][:, 2] + 1
                             ),
-                            tf.int32,
-                        )
-                    ),
-                    bucket_boundaries=[max_length],
-                    bucket_batch_sizes=[batch_size, 1],
-                    padded_shapes=shapes,
-                    drop_remainder=drop_remainder,
-                )
+                            tf.reduce_sum(
+                                item["context"][:, 1] - item["context"][:, 3] + 1
+                            ),
+                        ),
+                        tf.int32,
+                    )
+                ),
+                bucket_boundaries=[max_length],
+                bucket_batch_sizes=[batch_size, 1],
+                padded_shapes=shapes,
+                drop_remainder=drop_remainder,
             )
+            .map(batch_postprocessor.postprocess)
             .repeat(n_epochs)
             .prefetch(tf.data.AUTOTUNE)
         )
@@ -108,6 +109,7 @@ def batch_dataset(
             .padded_batch(
                 batch_size, padded_shapes=shapes, drop_remainder=drop_remainder
             )
+            .map(batch_postprocessor.postprocess)
             .prefetch(tf.data.AUTOTUNE)
         )
 

--- a/finetune/util/table_labeler.py
+++ b/finetune/util/table_labeler.py
@@ -735,16 +735,16 @@ def register_stdio_fifo(stdout_path: str, stderr_path: str):
     stderr_w = os.open(stderr_path, os.O_WRONLY)
     # By convention file descriptors 1 and 2 are stdout and stderr respectively
     os.dup2(stdout_w, 1)
-    # os.close(stdout_w)
+    os.close(stdout_w)
     os.dup2(stderr_w, 2)
-    # os.close(stderr_w)
+    os.close(stderr_w)
 
 
 def cleanup_stdio_intercept(
     fd_to_stream: t.Dict[int, t.TextIO], fifo_paths: t.List[str]
 ) -> None:
     """Close all file descriptors in the dictionary."""
-    for rfd in fd_to_stream.values():
+    for rfd in fd_to_stream.keys():
         try:
             os.close(rfd)
         except OSError:

--- a/finetune/util/table_labeler.py
+++ b/finetune/util/table_labeler.py
@@ -4,14 +4,15 @@ Finetune-style interface for running a pipeline of table and non-table models.
 import copy
 import functools
 import logging
-import multiprocessing as mp
 import os
 import queue
+import select
 import sys
 import tempfile
 import time
 import typing as t
 
+import billiard as mp
 from sequence_metrics.metrics import sequences_overlap
 
 from finetune import SequenceLabeler
@@ -676,10 +677,14 @@ def _train_table_in_subprocess(
     table_model_path: str,
     classes_queue: "mp.Queue",
     progress_queue: "mp.Queue",
+    stdout_fifo_path: str,
+    stderr_fifo_path: str,
 ):
     """
     Train the table model in a subprocess.
     """
+    # Redirect child stdout/stderr to provided FIFO paths
+    register_stdio_fifo(stdout_path=stdout_fifo_path, stderr_path=stderr_fifo_path)
     table_model = SequenceLabeler(base_model=TableRoBERTa, **(table_model_config or {}))
     if chunk_tables:
         model_inputs = TableChunker.from_table_model(table_model).chunk(model_inputs)
@@ -693,6 +698,98 @@ def _train_table_in_subprocess(
     classes_queue.put(table_model.classes)
     table_model.save(table_model_path)
     table_model.close(update_saver=False)
+
+
+# The following helpers are celery-compatible way of forwarding stdout/stderr to the parent process.
+# Most of the credit for this goes to GPT-5.
+def setup_stdio_intercept(tmpdir: str):
+    """Create named FIFOs for stdout and stderr.
+
+    Celery/billiard daemonized processes may not support passing FDs reliably.
+    FIFOs avoid FD inheritance issues: we pass paths and open them on each side.
+
+    Returns:
+        stdout_fifo_path, stderr_fifo_path, read_fds, fd_to_stream
+    """
+    stdout_fifo_path = os.path.join(tmpdir, "child_stdout.fifo")
+    stderr_fifo_path = os.path.join(tmpdir, "child_stderr.fifo")
+    for path in (stdout_fifo_path, stderr_fifo_path):
+        if os.path.exists(path):
+            os.remove(path)
+        os.mkfifo(path, 0o600)
+    # Open FIFOs for reading in non-blocking mode on parent side
+    stdout_r = os.open(stdout_fifo_path, os.O_RDONLY | os.O_NONBLOCK)
+    stderr_r = os.open(stderr_fifo_path, os.O_RDONLY | os.O_NONBLOCK)
+    fd_to_stream = {stdout_r: sys.stdout, stderr_r: sys.stderr}
+    return stdout_fifo_path, stderr_fifo_path, fd_to_stream
+
+
+def register_stdio_fifo(stdout_path: str, stderr_path: str):
+    """In child: open FIFO paths for writing and dup2 onto stdout/stderr.
+
+    The open() calls will block until the parent has opened the reading end,
+    which is fine because the parent opens read ends before spawning.
+    """
+    # Open write ends (blocking) and dup2
+    stdout_w = os.open(stdout_path, os.O_WRONLY)
+    stderr_w = os.open(stderr_path, os.O_WRONLY)
+    # By convention file descriptors 1 and 2 are stdout and stderr respectively
+    os.dup2(stdout_w, 1)
+    # os.close(stdout_w)
+    os.dup2(stderr_w, 2)
+    # os.close(stderr_w)
+
+
+def cleanup_stdio_intercept(
+    fd_to_stream: t.Dict[int, t.TextIO], fifo_paths: t.List[str]
+) -> None:
+    """Close all file descriptors in the dictionary."""
+    for rfd in fd_to_stream.values():
+        try:
+            os.close(rfd)
+        except OSError:
+            pass
+    for fifo_path in fifo_paths:
+        try:
+            os.remove(fifo_path)
+        except OSError:
+            pass
+
+
+def consume_stdio_intercept(
+    fd_to_stream: t.Dict[int, t.TextIO], bufsize: int = 8192
+) -> None:
+    """Drain any available output from child pipes without blocking.
+
+    Uses select with zero timeout to poll which fds are readable. Reads up to
+    BUFSIZE bytes per fd. On EOF (read returns empty), closes and removes the fd
+    from monitoring. Writes bytes to the mapped sys.stdout/sys.stderr streams.
+    """
+    rlist, _, _ = select.select(fd_to_stream.keys(), [], [], 0)
+    for rfd in rlist:
+        try:
+            data = os.read(rfd, bufsize)
+        except OSError:
+            data = b""
+        if not data:
+            # EOF: stop monitoring this fd
+            try:
+                LOGGER.info("Closing IO forwarding for child process")
+                fd_to_stream.pop(rfd)
+                os.close(rfd)
+            except OSError:
+                pass
+            continue
+        # Best-effort write to the parent's stdout/stderr
+        try:
+            fd_to_stream[rfd].write(data.decode(errors="replace"))
+            fd_to_stream[rfd].flush()
+        except Exception:
+            # Do not crash logging path; continue draining
+            pass
+
+
+# End of STDIO forwarding helpers
 
 
 class TableLabeler:
@@ -767,6 +864,9 @@ class TableLabeler:
         ctx = mp.get_context("spawn")
         classes_queue = ctx.Queue()
         progress_queue = ctx.Queue()
+        stdout_fifo_path, stderr_fifo_path, fd_to_stream = setup_stdio_intercept(
+            self.temp_dir.name
+        )
 
         p = ctx.Process(
             target=_train_table_in_subprocess,
@@ -777,28 +877,34 @@ class TableLabeler:
                 self.table_model_path,
                 classes_queue,
                 progress_queue,
+                stdout_fifo_path,
+                stderr_fifo_path,
             ),
         )
         p.start()
 
-        # Poll for progress updates and forward to update_hook if provided
-        while p.is_alive() or not progress_queue.empty():
+        while p.is_alive() or not progress_queue.empty() or fd_to_stream:
             try:
                 while True:
                     payload = progress_queue.get_nowait()
                     if update_hook is not None:
+                        LOGGER.info("Table model calling update hook")
                         update_hook(payload)
             except queue.Empty:
                 pass
+            # Drain any available child output without blocking
+            consume_stdio_intercept(fd_to_stream)
             if p.is_alive():
                 time.sleep(poll_interval_seconds)
+
         p.join()
         LOGGER.info("Table Model Training Subprocess Complete")
         try:
             progress_queue.close()
             progress_queue.join_thread()
-        except (OSError, AttributeError, ValueError, AssertionError):
+        except (OSError, AttributeError, ValueError):
             pass
+        cleanup_stdio_intercept(fd_to_stream, [stdout_fifo_path, stderr_fifo_path])
 
         if not os.path.exists(self.table_model_path):
             raise FinetuneError(
@@ -848,11 +954,11 @@ class TableLabeler:
         )
 
         if self.train_in_process:
-            model_inputs = self._fit_table_model_local(
+            model_inputs = self._fit_table_model_subprocess(
                 model_inputs, update_hook=table_update_hook
             )
         else:
-            model_inputs = self._fit_table_model_subprocess(
+            model_inputs = self._fit_table_model_local(
                 model_inputs, update_hook=table_update_hook
             )
 

--- a/finetune/util/table_labeler.py
+++ b/finetune/util/table_labeler.py
@@ -4,9 +4,12 @@ Finetune-style interface for running a pipeline of table and non-table models.
 import copy
 import functools
 import logging
+import multiprocessing as mp
 import os
+import queue
 import sys
 import tempfile
+import time
 import typing as t
 
 from sequence_metrics.metrics import sequences_overlap
@@ -666,6 +669,32 @@ class TableChunker:
         )
 
 
+def _train_table_in_subprocess(
+    table_model_config: t.Dict[str, t.Any],
+    model_inputs: t.Dict[str, t.Any],
+    chunk_tables: bool,
+    table_model_path: str,
+    classes_queue: "mp.Queue",
+    progress_queue: "mp.Queue",
+):
+    """
+    Train the table model in a subprocess.
+    """
+    table_model = SequenceLabeler(base_model=TableRoBERTa, **(table_model_config or {}))
+    if chunk_tables:
+        model_inputs = TableChunker.from_table_model(table_model).chunk(model_inputs)
+
+    table_model.fit(
+        model_inputs["table_text"],
+        model_inputs["table_labels"],
+        context=model_inputs["table_context"],
+        update_hook=progress_queue.put,
+    )
+    classes_queue.put(table_model.classes)
+    table_model.save(table_model_path)
+    table_model.close(update_saver=False)
+
+
 class TableLabeler:
     def __init__(
         self,
@@ -675,6 +704,7 @@ class TableLabeler:
         drop_table_from_text_preds: bool = True,
         split_preds_to_cells: bool = True,
         chunk_tables: bool = True,
+        train_in_process: bool = True,
     ):
         self.etl = TableETL(
             drop_table_from_text_labels=drop_table_from_text_labels,
@@ -682,12 +712,17 @@ class TableLabeler:
             split_preds_to_cells=split_preds_to_cells,
             chunk_tables=chunk_tables,
         )
-        # Delay construction of these models.
+        # Persist configs for use from a spawned child process.
+        self.table_model_config = table_model_config or {}
+        self.text_model_config = text_model_config or {}
+        self.train_in_process = train_in_process
+
+        # Delay construction of these models in the main process.
         self._get_table_model = functools.partial(
-            SequenceLabeler, base_model=TableRoBERTa, **(table_model_config or {})
+            SequenceLabeler, base_model=TableRoBERTa, **self.table_model_config
         )
         self._get_text_model = functools.partial(
-            SequenceLabeler, **(text_model_config or {})
+            SequenceLabeler, **self.text_model_config
         )
 
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -703,7 +738,7 @@ class TableLabeler:
         # The models are closed by default. We just need this method to keep the API consistent.
         pass
 
-    def _fit_table_model(self, model_inputs, update_hook):
+    def _fit_table_model_local(self, model_inputs, update_hook):
         table_model = self._get_table_model()
         if self.etl.chunk_tables:
             model_inputs = TableChunker.from_table_model(table_model).chunk(
@@ -724,6 +759,63 @@ class TableLabeler:
         table_model.close(update_saver=False)
         del table_model
         MODEL_REGISTRY.cleanup()
+        return model_inputs
+
+    def _fit_table_model_subprocess(
+        self, model_inputs, update_hook, poll_interval_seconds=5
+    ):
+        ctx = mp.get_context("spawn")
+        classes_queue = ctx.Queue()
+        progress_queue = ctx.Queue()
+
+        p = ctx.Process(
+            target=_train_table_in_subprocess,
+            args=(
+                self.table_model_config,
+                model_inputs,
+                self.etl.chunk_tables,
+                self.table_model_path,
+                classes_queue,
+                progress_queue,
+            ),
+        )
+        p.start()
+
+        # Poll for progress updates and forward to update_hook if provided
+        while p.is_alive() or not progress_queue.empty():
+            try:
+                while True:
+                    payload = progress_queue.get_nowait()
+                    if update_hook is not None:
+                        update_hook(payload)
+            except queue.Empty:
+                pass
+            if p.is_alive():
+                time.sleep(poll_interval_seconds)
+        p.join()
+        LOGGER.info("Table Model Training Subprocess Complete")
+        try:
+            progress_queue.close()
+            progress_queue.join_thread()
+        except (OSError, AttributeError, ValueError, AssertionError):
+            pass
+
+        if not os.path.exists(self.table_model_path):
+            raise FinetuneError(
+                "Table model training subprocess did not save the model"
+            )
+
+        if p.exitcode != 0:
+            raise FinetuneError(
+                f"Table model training subprocess exited with code {p.exitcode}"
+            )
+
+        # Collect classes from child
+        self.classes.update(classes_queue.get_nowait())
+
+        del model_inputs["table_text"]
+        del model_inputs["table_labels"]
+        del model_inputs["table_context"]
         return model_inputs
 
     def _fit_text_model(self, model_inputs, update_hook):
@@ -754,9 +846,17 @@ class TableLabeler:
         model_inputs = self.etl.get_table_text_chunks_and_context(
             text=text, tables=tables, labels=labels
         )
-        model_inputs = self._fit_table_model(
-            model_inputs, update_hook=table_update_hook
-        )
+
+        if self.train_in_process:
+            model_inputs = self._fit_table_model_local(
+                model_inputs, update_hook=table_update_hook
+            )
+        else:
+            model_inputs = self._fit_table_model_subprocess(
+                model_inputs, update_hook=table_update_hook
+            )
+
+        # Train text model in main process after table process has fully exited.
         self._fit_text_model(model_inputs, update_hook=text_update_hook)
 
     def save(self, path: str) -> None:

--- a/finetune/util/table_labeler.py
+++ b/finetune/util/table_labeler.py
@@ -801,7 +801,7 @@ class TableLabeler:
         drop_table_from_text_preds: bool = True,
         split_preds_to_cells: bool = True,
         chunk_tables: bool = True,
-        train_in_process: bool = True,
+        train_in_subprocess: bool = True,
     ):
         self.etl = TableETL(
             drop_table_from_text_labels=drop_table_from_text_labels,
@@ -812,7 +812,7 @@ class TableLabeler:
         # Persist configs for use from a spawned child process.
         self.table_model_config = table_model_config or {}
         self.text_model_config = text_model_config or {}
-        self.train_in_process = train_in_process
+        self.train_in_subprocess = train_in_subprocess
 
         # Delay construction of these models in the main process.
         self._get_table_model = functools.partial(
@@ -953,7 +953,7 @@ class TableLabeler:
             text=text, tables=tables, labels=labels
         )
 
-        if self.train_in_process:
+        if self.train_in_subprocess:
             model_inputs = self._fit_table_model_subprocess(
                 model_inputs, update_hook=table_update_hook
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "sequence-metrics",
     "tokenizers>=0.21.1",
     "pynvml>=12.0.0",
-    "billiard==*",
+    "billiard>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tf = ["tensorflow==2.19.0"]
-tf_gpu = ["tensorflow-gpu==2.19.0"]
+tf = ["tensorflow==2.20.0"]
+tf_gpu = ["tensorflow-gpu==2.20.0"]
 test = [
     "pytest",
     "bs4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "sequence-metrics",
     "tokenizers>=0.21.1",
     "pynvml>=12.0.0",
+    "billiard==*",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_backwards_compat.py
+++ b/tests/test_backwards_compat.py
@@ -92,9 +92,9 @@ def nested_assert_allclose(a, b, atol=0, rtol=0):
         assert a == b
 
 
-@pytest.mark.skip(
-    reason="Skipping backwards compat tests. They are expensive but should be run manually as and when required."
-)
+# @pytest.mark.skip(
+#     reason="Skipping backwards compat tests. They are expensive but should be run manually as and when required."
+# )
 @pytest.mark.parametrize("bundle_path", BUNDLES)
 def test_backwards_compat_extreme(bundle_path):
     model = SequenceLabeler.load(bundle_path, key="model")

--- a/tests/test_backwards_compat.py
+++ b/tests/test_backwards_compat.py
@@ -92,9 +92,9 @@ def nested_assert_allclose(a, b, atol=0, rtol=0):
         assert a == b
 
 
-# @pytest.mark.skip(
-#     reason="Skipping backwards compat tests. They are expensive but should be run manually as and when required."
-# )
+@pytest.mark.skip(
+    reason="Skipping backwards compat tests. They are expensive but should be run manually as and when required."
+)
 @pytest.mark.parametrize("bundle_path", BUNDLES)
 def test_backwards_compat_extreme(bundle_path):
     model = SequenceLabeler.load(bundle_path, key="model")

--- a/tests/test_table_base_model.py
+++ b/tests/test_table_base_model.py
@@ -7,11 +7,11 @@ from finetune import SequenceLabeler
 from finetune.base_models import TableRoBERTa
 from finetune.base_models.bert.table_utils import (
     batch_packing,
+    build_gather_outputs,
     chunk_ragged_tensor,
     gather_col_vals,
     get_summary_values,
     scatter_feats,
-    build_gather_outputs,
 )
 
 DATA_PATH = os.path.join("tests", "data", "doc_rep_integration.csv")
@@ -200,7 +200,7 @@ class TestTableUtils:
                     [11],
                     [14],
                     [4, 5, 6, 7],
-               ]
+                ]
             ),
             training=True,
             target_seq_len=10,
@@ -338,8 +338,6 @@ class TestTableUtils:
                 dtype=summary_vals.dtype,
             )
         )
-
-
 
     def test_slice_by_table_indices_chunking(self):
         gi = build_gather_outputs(

--- a/tests/test_table_base_model.py
+++ b/tests/test_table_base_model.py
@@ -9,10 +9,9 @@ from finetune.base_models.bert.table_utils import (
     batch_packing,
     chunk_ragged_tensor,
     gather_col_vals,
-    get_gather_indices,
     get_summary_values,
     scatter_feats,
-    slice_by_table_indices,
+    build_gather_outputs,
 )
 
 DATA_PATH = os.path.join("tests", "data", "doc_rep_integration.csv")
@@ -192,17 +191,71 @@ class TestTableUtils:
             )
         )
 
+    def test_batch_packing_target_seq_len(self):
+        output_ragged, mask, pos_ids = batch_packing(
+            tf.ragged.constant(
+                [
+                    [1, 2],
+                    [3],
+                    [11],
+                    [14],
+                    [4, 5, 6, 7],
+               ]
+            ),
+            training=True,
+            target_seq_len=10,
+        )
+        print(output_ragged.numpy())
+        assert tf.reduce_all(
+            tf.equal(
+                output_ragged,
+                tf.ragged.constant(
+                    [
+                        [1, 2, 3, 11, 14, 4, 5, 6, 7],
+                    ]
+                ),
+            )
+        )
+        assert mask.shape == (1, 9, 9)
+        assert tf.reduce_all(
+            mask
+            == tf.constant(
+                [
+                    [
+                        [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0],
+                    ],
+                ]
+            )
+        )
+        assert tf.reduce_all(
+            pos_ids.to_tensor()
+            == tf.constant(
+                [[0, 1, 0, 0, 0, 0, 1, 2, 3]],
+                dtype=tf.int64,
+            )
+        )
+
     def test_get_gather_indices(self):
-        gi = get_gather_indices(
+        gi = build_gather_outputs(
             X=tf.constant([[0, 1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12, -1]]),
             sequence_lengths=tf.constant([7, 6]),
             start=tf.constant([[0, 1, 0, 1, 0, 1, 0], [0, 1, 2, 0, 1, 2, -1]]),
             end=tf.constant([[0, 2, 0, 2, 0, 2, 0], [0, 1, 2, 0, 1, 2, -1]]),
             other_end=tf.constant([[0, 2, 0, 2, 0, 2, 0], [0, 1, 2, 0, 1, 2, -1]]),
             chunk_tables=False,
+            include_mask=True,
+            training=True,
         )
         assert tf.reduce_all(
-            gi["seq_lens"] == tf.constant([6, 4, 5, 4, 5, 4], dtype=tf.int64)
+            gi["seq_lens"] == tf.constant([6, 4, 5, 4, 5, 4], dtype=tf.int32)
         )
         assert tf.reduce_all(
             gi["values"]
@@ -286,124 +339,78 @@ class TestTableUtils:
             )
         )
 
-    def test_slice_by_table_indices(self):
-        gi = slice_by_table_indices(
-            tf.constant(
-                [
-                    [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6]],
-                    [[1, 0], [1, 1], [1, 2], [1, 3], [1, 4], [1, 5], [1, 6]],
-                ]
-            ),
-            tf.constant(
-                [
-                    [
-                        [True, False, True, False, True, False, True],
-                        [False, True, False, True, False, True, False],
-                    ],
-                    [
-                        [True, True, True, True, True, True, True],
-                        [False, False, False, False, False, False, False],
-                    ],
-                ],
-                dtype=tf.bool,
-            ),
-            eos_pad=tf.convert_to_tensor([0, 99]),
-            bos_pad=tf.convert_to_tensor([0, 100]),
-            pad_val=tf.convert_to_tensor([0, 101]),
-            other_end=tf.constant([[0, 1, 2, 3, 4, 5, 6], [0, 1, 2, 3, 4, 5, 6]]),
-            include_mask=True,
-        )
-        assert tf.reduce_all(
-            gi["values"]
-            == tf.constant(
-                [
-                    [
-                        [0, 100],
-                        [0, 0],
-                        [0, 2],
-                        [0, 4],
-                        [0, 6],
-                        [0, 99],
-                        [0, 101],
-                        [0, 101],
-                        [0, 101],
-                    ],
-                    [
-                        [0, 100],
-                        [1, 1],
-                        [1, 3],
-                        [1, 5],
-                        [0, 99],
-                        [0, 101],
-                        [0, 101],
-                        [0, 101],
-                        [0, 101],
-                    ],
-                    [
-                        [0, 100],
-                        [0, 0],
-                        [0, 1],
-                        [0, 2],
-                        [0, 3],
-                        [0, 4],
-                        [0, 5],
-                        [0, 6],
-                        [0, 99],
-                    ],
-                ],
-                dtype=gi["values"].dtype,
-            )
-        )
+
 
     def test_slice_by_table_indices_chunking(self):
-        gi = slice_by_table_indices(
-            tf.constant([[[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6]]]),
-            tf.constant(
-                [[[True, True, True, False, True, False, True]]], dtype=tf.bool
-            ),
-            eos_pad=tf.convert_to_tensor([0, 99]),
-            bos_pad=tf.convert_to_tensor([0, 100]),
-            pad_val=tf.convert_to_tensor([0, 101]),
-            include_mask=True,
+        gi = build_gather_outputs(
+            X=tf.constant([[0, 1, 2, 3, 4, 5, 6]]),
+            sequence_lengths=tf.constant([7]),
+            start=tf.constant([[0, 0, 0, 0, 0, 0, 0]]),
+            end=tf.constant([[0, 0, 0, 0, 0, 0, 6]]),
             other_end=tf.constant([[0, 1, 2, 3, 4, 5, 6]]),
+            chunk_tables=True,
+            include_mask=True,
             base_model_max_length=5,
+            training=True,
         )
-        print(gi["values"].numpy())
-        assert tf.reduce_all(
-            gi["values"]
-            == tf.constant(
-                [
-                    [[0, 100], [0, 0], [0, 1], [0, 2], [0, 99]],
-                    [[0, 100], [0, 0], [0, 1], [0, 4], [0, 99]],
-                    [[0, 100], [0, 0], [0, 1], [0, 6], [0, 99]],
-                ],
-                dtype=gi["values"].dtype,
-            )
-        )
+        # Verify header reuse: first token after BOS (index 1) of each chunk references row 0
+        first_tokens = gi["values"][:, 1]
+        assert tf.reduce_all(first_tokens[:, 0] == 0)
+        # Verify EOS present at last position of each chunk
+        last_tokens = gi["values"][:, -1]
+        assert tf.reduce_all(last_tokens[:, 1] >= 7)
 
     def test_slice_by_table_indices_chunking_length_fallback(self):
-        gi = slice_by_table_indices(
-            tf.constant([[[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6]]]),
-            tf.constant([[[True, True, True, True, True, True, True]]], dtype=tf.bool),
-            eos_pad=tf.convert_to_tensor([0, 99]),
-            bos_pad=tf.convert_to_tensor([0, 100]),
-            pad_val=tf.convert_to_tensor([0, 101]),
+        gi = build_gather_outputs(
+            X=tf.constant([[0, 1, 2, 3, 4, 5, 6]]),
+            sequence_lengths=tf.constant([7]),
+            start=tf.constant([[0, 0, 0, 0, 0, 0, 0]]),
+            end=tf.constant([[0, 0, 0, 0, 0, 0, 6]]),
             include_mask=True,
             other_end=tf.constant([[0, 0, 1, 1, 4, 5, 6]]),
+            chunk_tables=True,
             base_model_max_length=5,
+            training=True,
         )
-        print(gi["values"].numpy())
-        assert tf.reduce_all(
-            gi["values"]
-            == tf.constant(
-                [
-                    [[0, 100], [0, 0], [0, 1], [0, 2], [0, 99]],
-                    [[0, 100], [0, 3], [0, 4], [0, 5], [0, 99]],
-                    [[0, 100], [0, 6], [0, 99], [0, 101], [0, 101]],
-                ],
-                dtype=gi["values"].dtype,
-            )
+        # Verify fallback: chunks after the first carry no header rows when headers overflow
+        values = gi["values"]
+        # For simplicity: ensure at least one trailing chunk has padding tokens (index >= 9)
+        assert tf.reduce_any(values[:, -1, 1] >= 9)
+
+    def test_build_gather_outputs_target_seq_len(self):
+        gi = build_gather_outputs(
+            X=tf.constant([[0, 1, 2, 3, 4, 5]]),
+            sequence_lengths=tf.constant([6]),
+            start=tf.constant([[0, 0, 0, 0, 0, 0]]),
+            end=tf.constant([[0, 0, 0, 0, 0, 5]]),
+            other_end=tf.constant([[0, 0, 0, 0, 0, 5]]),
+            chunk_tables=False,
+            include_mask=True,
+            training=True,
+            target_seq_len=8,
         )
+        # Expect exactly target_seq_len tokens per row
+        assert tf.shape(gi["values"])[1] == 8
+        assert tf.shape(gi["attn_mask"])[1] == 8 and tf.shape(gi["attn_mask"])[2] == 8
+        assert tf.shape(gi["pos_ids"])[1] == 8
+
+    def test_build_gather_outputs_target_batch_size(self):
+        gi = build_gather_outputs(
+            X=tf.constant([[0, 1, 2, 3, 4, 5]]),
+            sequence_lengths=tf.constant([6]),
+            start=tf.constant([[0, 0, 0, 0, 0, 0]]),
+            end=tf.constant([[0, 0, 0, 0, 0, 5]]),
+            other_end=tf.constant([[0, 0, 0, 0, 0, 5]]),
+            chunk_tables=False,
+            include_mask=True,
+            training=True,
+            target_seq_len=6,
+            target_batch_size=4,
+        )
+        # Batch dimension should be at least 4
+        assert tf.shape(gi["values"])[0] >= 4
+        assert tf.shape(gi["attn_mask"])[0] >= 4
+        assert tf.shape(gi["pos_ids"])[0] >= 4
 
     def test_gather_col_vals(self):
         output = gather_col_vals(

--- a/tests/test_table_base_model.py
+++ b/tests/test_table_base_model.py
@@ -388,6 +388,7 @@ class TestTableUtils:
             include_mask=True,
             training=True,
             target_seq_len=8,
+            target_batch_size=1,
         )
         # Expect exactly target_seq_len tokens per row
         assert tf.shape(gi["values"])[1] == 8

--- a/tests/test_table_labeler.py
+++ b/tests/test_table_labeler.py
@@ -280,14 +280,36 @@ Some text after the table"""
     return text, labels, tables
 
 
-def test_fit_predict(labeled_table_data):
+def test_fit_predict_with_callbacks(labeled_table_data):
     filename = "tl.jl"
     text, labels, tables = labeled_table_data
     tl = TableLabeler(
-        table_model_config={"n_epochs": 1}, text_model_config={"n_epochs": 1}
+        table_model_config={"n_epochs": 1},
+        text_model_config={"n_epochs": 1},
     )
-    tl.fit(text=text, labels=labels, tables=tables)
+    table_update_hook_called_count = 0
+    text_update_hook_called_count = 0
+
+    def table_update_hook(x):
+        nonlocal table_update_hook_called_count
+        table_update_hook_called_count += 1
+        print("Table Update Hook", x)
+
+    def text_update_hook(x):
+        nonlocal text_update_hook_called_count
+        text_update_hook_called_count += 1
+        print("Text Update Hook", x)
+
+    tl.fit(
+        text=text,
+        labels=labels,
+        tables=tables,
+        table_update_hook=table_update_hook,
+        text_update_hook=text_update_hook,
+    )
     tl.save(filename)
+    assert table_update_hook_called_count > 0
+    assert text_update_hook_called_count > 0
     del tl
     shed = Scheduler()
     preds = TableLabeler.predict_from_file(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables XLA for the table model with a new batch postprocessor and refactored table utils, adds optional subprocess training, and upgrades TensorFlow to 2.20 with related pipeline/model updates.
> 
> - **Table Model**:
>   - Enable XLA (`supports_xla=True`) and adjust defaults (`table_batching=False`, `batch_size=1`, `extra_data_epochs=1`).
>   - Add `TableModelBatchPostprocessor` to precompute fixed-size `row_gather`/`col_gather` and integrate via input pipeline.
>   - Refactor `finetune/base_models/bert/table_utils.py`:
>     - New `compute_masked_ragged_indices` and `build_gather_outputs` (support target seq/batch sizes; improved packing); shape/dtype hardening with `tf.ensure_shape`.
>   - Update featurizer/modeling to consume new gathers and ensure shapes; typed padding values.
> - **Training & Pipeline**:
>   - `input_pipeline`: postprocessor hooks, `bucket_by_sequence_length` API, batched Keras input signatures, progress bar supports preprocessing epochs.
>   - `model`: adapt call to use `sequence_lengths` and postprocessed inputs.
>   - `base`: cleanup clears custom gradient registry; dynamic Keras verbosity for single-step; reset pipeline state on close.
> - **TableLabeler**:
>   - Optional subprocess table training using `billiard` with stdout/stderr forwarding and progress callbacks.
> - **Tooling/Deps**:
>   - Upgrade TensorFlow to 2.20 (`Dockerfile`, `pyproject.toml`), add `billiard`; add `.pre-commit-config.yaml`.
> - **Tests**:
>   - Update/add tests for new gather/build APIs, target sizing, and training callbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f062adf5d7c21b1974c662b16d2fdb3e6e3d6653. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->