### PR TITLE
FIX: [DEV-14438] ModernBert Accuracy new predict batch size default

### DIFF
--- a/finetune/base.py
+++ b/finetune/base.py
@@ -191,6 +191,7 @@ class BaseModel(object, metaclass=ABCMeta):
         current_predict_batch = config.get("predict_batch_size")
         if (
             override_predict_batch is not None
+            and current_predict_batch is not None
             and override_predict_batch < current_predict_batch
             and hasattr(self, "config")
         ):

--- a/finetune/base.py
+++ b/finetune/base.py
@@ -187,6 +187,18 @@ class BaseModel(object, metaclass=ABCMeta):
                 raise ValueError("There is no auto setting for {}".format(ak))
             config[ak] = overrides[ak]
 
+        override_predict_batch = overrides.get("predict_batch_size")
+        current_predict_batch = config.get("predict_batch_size")
+        if (
+            override_predict_batch is not None
+            and override_predict_batch < current_predict_batch
+            and hasattr(self, "config")
+        ):
+            LOGGER.info(
+                f"Overriding loaded predict batch size from {current_predict_batch} to the new default of {override_predict_batch}"
+            )
+            self.config["predict_batch_size"] = override_predict_batch
+
         if hasattr(self, "input_pipeline"):
             self.input_pipeline.config = config
 

--- a/finetune/base_models/modern_bert/model.py
+++ b/finetune/base_models/modern_bert/model.py
@@ -73,7 +73,7 @@ class ModernBertModel(_ModernBertBase):
                 "n_epochs": base_n_epochs,
                 "batch_size": 8,
                 "chunk_context": None,
-                "predict_batch_size": 16,
+                "predict_batch_size": 8,
                 "mixed_precision": True,
                 "float_16_predict": True,
                 "lr": base_learning_rate,

--- a/tests/test_backwards_compat.py
+++ b/tests/test_backwards_compat.py
@@ -1,5 +1,6 @@
 import glob
 import os
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -43,6 +44,20 @@ def test_roberta_default_no_change(get_untrained_sequence_labeler):
     model.save("./test_model.jl")
     model = SequenceLabeler.load("./test_model.jl")
     assert model.config.collapse_whitespace == True
+
+
+def test_table_model_predict_batch_size_override(monkeypatch):
+    model_path = (
+        Path(__file__).parent
+        / "backwards_compat_bundles"
+        / "ModernBertModel_sequence_labeling_crf_True.jl"
+    )
+    model = SequenceLabeler.load(model_path, key="model")
+    try:
+        assert model.config.optimize_for.lower() == "accuracy"
+        assert model.config.predict_batch_size == 8
+    finally:
+        model.close()
 
 
 # TODO: eventually clean this up and push these files to s3.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reduces ModernBert accuracy profile `predict_batch_size` to 8 and ensures loaded models adopt the smaller default; adds a test to validate.
> 
> - **Model/Config**:
>   - **ModernBert accuracy profile**: Change `predict_batch_size` from `16` to `8` in `finetune/base_models/modern_bert/model.py`.
>   - **Config resolution on load**: In `finetune/base.py`, when resolving config, if the new default `predict_batch_size` is smaller than the loaded value, override it and log the change.
> - **Tests**:
>   - Add `test_table_model_predict_batch_size_override` in `tests/test_backwards_compat.py` to assert `optimize_for == "accuracy"` and `predict_batch_size == 8` for a saved bundle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e81955e11ffed552013dd1d832c1eb034585642c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->